### PR TITLE
Show tmux modes

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -105,9 +105,18 @@ set  -g status-justify centre
 set  -g status-interval 2
 set  -g status-position bottom
 set  -g status-style bg=default,fg=default,none
-set -g status-left-length 30
+set -g status-left-length 50
 set -g status-right-length 60
-set  -g status-left " #[fg=$thm_black4,bg=$thm_bg]#[fg=$thm_cyan,bg=$thm_black4] #S | #h #[fg=$thm_black4, bg=$thm_bg] "
+set -g @prefix_highlight_fg $thm_cyan
+set -g @prefix_highlight_bg $thm_red
+set -g @prefix_highlight_copy_mode_attr "fg=$thm_cyan,bg=$thm_magenta"
+set -g @prefix_highlight_sync_mode_attr "fg=$thm_cyan,bg=$thm_magenta"
+set -g @prefix_highlight_show_copy_mode 'on'
+set -g @prefix_highlight_show_sync_mode 'on'
+set -g @prefix_highlight_prefix_prompt ''
+set -g @prefix_highlight_copy_prompt ''
+set -g @prefix_highlight_sync_prompt ''
+set  -g status-left " #[fg=$thm_black4,bg=$thm_bg]#[fg=$thm_cyan,bg=$thm_black4]#{prefix_highlight}#[fg=$thm_cyan,bg=$thm_black4] #S | #h #[fg=$thm_black4, bg=$thm_bg] "
 set  -g status-right " #[fg=$thm_black4,bg=$thm_bg]#[fg=$thm_cyan,bg=$thm_black4] %d-%b-%y | #(gitmux -cfg $HOME/.config/gitmux.conf '#{pane_current_path}')#[fg=$thm_black4,bg=$thm_bg] "
 
 setw -g window-status-separator ' '
@@ -153,8 +162,6 @@ set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @resurrect-strategy-nvim 'session'
 set -g @continuum-restore 'on'
 set -g @continuum-save-interval '2'
-
-set -g @plugin 'yardnsm/tmux-1password'
 
 # ==================== Bindings ====================
 


### PR DESCRIPTION
I'm less confident I've entered modes on my new keyboard.


This pull request includes changes to the `tmux.conf` file to modify the status bar and remove a plugin. The status bar's left length has been increased and several new settings have been added to customize the prefix highlight. Additionally, the `yardnsm/tmux-1password` plugin has been removed.

* [`tmux.conf`](diffhunk://#diff-0aaf8ca3708e1c3e0398ec5fc5e738c3b3e556af19a7e836af62d41c4bd36f8dL108-R119): Increased the status bar's left length from 30 to 50 and added new settings to customize the prefix highlight. These settings include foreground and background colors, copy mode and sync mode attributes, and prompts for each mode. The status bar's left content has also been updated to include the prefix highlight.
* [`tmux.conf`](diffhunk://#diff-0aaf8ca3708e1c3e0398ec5fc5e738c3b3e556af19a7e836af62d41c4bd36f8dL157-L158): Removed the `yardnsm/tmux-1password` plugin.