### PR TITLE
Navigation and testing

### DIFF
--- a/nvim/lua/keys.lua
+++ b/nvim/lua/keys.lua
@@ -1,8 +1,8 @@
 -- Move around splits with <c-hjkl>
-vim.keymap.set("n", "<C-k>", "<C-w><Up>")
-vim.keymap.set("n", "<C-j>", "<C-w><Down>")
-vim.keymap.set("n", "<C-l>", "<C-w><Right>")
-vim.keymap.set("n", "<C-h>", "<C-w><Left>")
+-- vim.keymap.set("n", "<C-k>", "<C-w><Up>")
+-- vim.keymap.set("n", "<C-j>", "<C-w><Down>")
+-- vim.keymap.set("n", "<C-l>", "<C-w><Right>")
+-- vim.keymap.set("n", "<C-h>", "<C-w><Left>")
 
 vim.keymap.set("i", "<C-k>", "<Up>")
 vim.keymap.set("i", "<C-j>", "<Down>")
@@ -43,6 +43,7 @@ vim.keymap.set("n", "<Leader>P", '"+P')
 
 -- Split
 vim.keymap.set("", "<leader>sp", ":split<cr>")
+vim.keymap.set("", "<leader>sh", ":split<cr>")
 vim.keymap.set("", "<leader>sv", ":vsplit<cr>")
 
 -- File operations

--- a/nvim/lua/plugins/neo-tree.lua
+++ b/nvim/lua/plugins/neo-tree.lua
@@ -64,7 +64,7 @@ return {
 			},
 		})
 		vim.keymap.set("n", "<leader>tg", ":Neotree toggle<CR>", {})
-		vim.keymap.set("n", "<leader>tf", ":Neotree filesystem reveal left<CR>", {})
+		vim.keymap.set("n", "<leader>tF", ":Neotree filesystem reveal left<CR>", {})
 		vim.keymap.set("n", "<leader>tb", ":Neotree buffers reveal float<CR>", {})
 	end,
 }

--- a/nvim/lua/plugins/vim-tmux-navigator.lua
+++ b/nvim/lua/plugins/vim-tmux-navigator.lua
@@ -1,0 +1,7 @@
+return {
+  "christoomey/vim-tmux-navigator",
+  vim.keymap.set('n', 'C-h', ':TmuxNavigateLeft<CR>'),
+  vim.keymap.set('n', 'C-j', ':TmuxNavigateDown<CR>'),
+  vim.keymap.set('n', 'C-k', ':TmuxNavigateUp<CR>'),
+  vim.keymap.set('n', 'C-l', ':TmuxNavigateRight<CR>'),
+}

--- a/nvim/lua/plugins/vim-tmux-navigator.lua
+++ b/nvim/lua/plugins/vim-tmux-navigator.lua
@@ -1,7 +1,7 @@
 return {
-  "christoomey/vim-tmux-navigator",
-  vim.keymap.set('n', 'C-h', ':TmuxNavigateLeft<CR>'),
-  vim.keymap.set('n', 'C-j', ':TmuxNavigateDown<CR>'),
-  vim.keymap.set('n', 'C-k', ':TmuxNavigateUp<CR>'),
-  vim.keymap.set('n', 'C-l', ':TmuxNavigateRight<CR>'),
+	"christoomey/vim-tmux-navigator",
+	vim.keymap.set("n", "C-h", ":TmuxNavigateLeft<CR>"),
+	vim.keymap.set("n", "C-j", ":TmuxNavigateDown<CR>"),
+	vim.keymap.set("n", "C-k", ":TmuxNavigateUp<CR>"),
+	vim.keymap.set("n", "C-l", ":TmuxNavigateRight<CR>"),
 }

--- a/nvim/lua/plugins/vimtest.lua
+++ b/nvim/lua/plugins/vimtest.lua
@@ -1,0 +1,12 @@
+return {
+	"vim-test/vim-test",
+	dependencies = {
+		"preservim/vimux",
+	},
+	vim.keymap.set("n", "<leader>tn", ":TestNearest<CR>"),
+	vim.keymap.set("n", "<leader>tf", ":TestFile<CR>"),
+	vim.keymap.set("n", "<leader>ts", ":TestSuite<CR>"),
+	vim.keymap.set("n", "<leader>tl", ":TestLast<CR>"),
+	vim.keymap.set("n", "<leader>tv", ":TestVisit<CR>"),
+	vim.cmd("let test#strategy = 'vimux'"),
+}

--- a/tmux.conf
+++ b/tmux.conf
@@ -150,6 +150,7 @@ set -g @plugin 'tmux-plugins/tmux-resurrect'
 
 # == Continuous saving of tmux environment. Automatic restore when tmux is started. Automatic tmux start when computer is turned on.
 
+set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @resurrect-strategy-nvim 'session'
 set -g @continuum-restore 'on'


### PR DESCRIPTION
This pull request primarily updates key mappings and plugin configurations in the Neovim and tmux environments. The changes include the disabling of certain key mappings for moving around splits in `nvim/lua/keys.lua`, addition of new plugins in `nvim/lua/plugins/vim-tmux-navigator.lua` and `nvim/lua/plugins/vimtest.lua`, and the addition of a new plugin in `tmux.conf`.