### PR TITLE
Oops, forgot to lazy load nav

### DIFF
--- a/nvim/lua/plugins/vim-tmux-navigator.lua
+++ b/nvim/lua/plugins/vim-tmux-navigator.lua
@@ -1,5 +1,6 @@
 return {
 	"christoomey/vim-tmux-navigator",
+	event = "VeryLazy",
 	vim.keymap.set("n", "C-h", ":TmuxNavigateLeft<CR>"),
 	vim.keymap.set("n", "C-j", ":TmuxNavigateDown<CR>"),
 	vim.keymap.set("n", "C-k", ":TmuxNavigateUp<CR>"),


### PR DESCRIPTION
This pull request includes a change to the `nvim/lua/plugins/vim-tmux-navigator.lua` file. The change introduces an event named "VeryLazy" to the vim-tmux-navigator plugin configuration.