### PR TITLE
Theme a bit more and another alias

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -37,6 +37,7 @@ fzf --fish | source
 alias gt="tmuxinator start github"
 alias pt="tmuxinator start personal"
 alias st="tmuxinator start server"
+alias fzg="rgf"
 
 if status is-interactive
   atuin init fish | source
@@ -56,3 +57,9 @@ if test -d ~/.asdf/plugins/golang
   source ~/.asdf/plugins/golang/set-env.fish
 end
 
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1e1e2e,spinner:#f5e0dc,hl:#f38ba8 \
+--color=fg:#cdd6f4,header:#f38ba8,info:#cba6f7,pointer:#f5e0dc \
+--color=marker:#b4befe,fg+:#cdd6f4,prompt:#cba6f7,hl+:#f38ba8 \
+--color=selected-bg:#45475a \
+--multi"

--- a/fish/fish_variables
+++ b/fish/fish_variables
@@ -5,6 +5,7 @@ SETUVAR --export BELA_SYSROOT:/Users/david/Code/Generator/bela/root/
 SETUVAR --export DARK_MODE:true
 SETUVAR --export EDITOR:nvim
 SETUVAR --export FIREFOX_DEVELOPER_BIN:/Applications/Firefox\x20Developer\x20Edition\x2eapp/Contents/MacOS/firefox\x2dbin
+SETUVAR --export FZF_DEFAULT_OPTS:\x2d\x2dcolor\x3dbg\x2b\x3a\x23313244\x2cbg\x3a\x231e1e2e\x2cspinner\x3a\x23f5e0dc\x2chl\x3a\x23f38ba8\x20\x2d\x2dcolor\x3dfg\x3a\x23cdd6f4\x2cheader\x3a\x23f38ba8\x2cinfo\x3a\x23cba6f7\x2cpointer\x3a\x23f5e0dc\x20\x2d\x2dcolor\x3dmarker\x3a\x23b4befe\x2cfg\x2b\x3a\x23cdd6f4\x2cprompt\x3a\x23cba6f7\x2chl\x2b\x3a\x23f38ba8\x20\x2d\x2dcolor\x3dselected\x2dbg\x3a\x2345475a\x20\x2d\x2dmulti
 SETUVAR --export ITERM_PROFILE:Light
 SETUVAR --export LSCOLORS:Exfxcxdxbxegedabagacad
 SETUVAR --export PYENV_ROOT:/Users/david/\x2epyenv

--- a/nvim/lua/plugins/catppuccin.lua
+++ b/nvim/lua/plugins/catppuccin.lua
@@ -17,7 +17,27 @@ return {
 				enabled = true,
 			},
 			integrations = {
-				treesitter = true,
+				aerial = true,
+				alpha = true,
+				blink_cmp = true,
+				copilot_vim = true,
+				dap = {
+					enabled = true,
+					enable_ui = true,
+				},
+				fzf = true,
+				gitsigns = true,
+				indent_blankline = {
+					enabled = true,
+					colored_indent_levels = false,
+				},
+				lsp_trouble = true,
+				mason = true,
+				neotree = {
+					enabled = true,
+					show_root = true,
+					transparent_panel = false,
+				},
 				native_lsp = {
 					enabled = true,
 					virtual_text = {
@@ -33,22 +53,13 @@ return {
 						information = { "underline" },
 					},
 				},
-				gitsigns = true,
-				lsp_trouble = true,
-				dap = {
+				neogit = true,
+				noice = true,
+				telescope = {
 					enabled = true,
-					enable_ui = true,
 				},
-				neotree = {
-					enabled = true,
-					show_root = true,
-					transparent_panel = false,
-				},
+				treesitter = true,
 				which_key = true,
-				indent_blankline = {
-					enabled = true,
-					colored_indent_levels = false,
-				},
 			},
 		})
 		vim.cmd([[colorscheme catppuccin]])


### PR DESCRIPTION
This pull request includes changes to the configuration files for the Fish shell and Neovim plugins. The most important changes include adding a new alias, setting environment variables for FZF, and updating the Neovim Catppuccin plugin integrations.
Configuration changes:

* [`fish/config.fish`](diffhunk://#diff-4713f065108ec97f8880b2dff7415204ea5dcafa97d0dfc65f49c2377113e498R40): Added a new alias `fzg` for `rgf` and set the `FZF_DEFAULT_OPTS` environment variable to customize the appearance and behavior of `fzf`. [[1]](diffhunk://#diff-4713f065108ec97f8880b2dff7415204ea5dcafa97d0dfc65f49c2377113e498R40) [[2]](diffhunk://#diff-4713f065108ec97f8880b2dff7415204ea5dcafa97d0dfc65f49c2377113e498R60-R65)
* [`fish/fish_variables`](diffhunk://#diff-8a72558574ce099478b0afac37eabbff4e0a475f7890e09004a0f1bedebc220fR8): Set the `FZF_DEFAULT_OPTS` environment variable with specific color options and enabled multi-selection.

Neovim plugin integrations:

* [`nvim/lua/plugins/catppuccin.lua`](diffhunk://#diff-86a35ea659f5370d2544367bd1502ff199585d069aa608eba4bcece8d4381ce4L20-R40): Added new integrations for various plugins including `aerial`, `alpha`, `blink_cmp`, `copilot_vim`, `dap`, `fzf`, `gitsigns`, `indent_blankline`, `lsp_trouble`, `mason`, `neotree`, `neogit`, `noice`, `telescope`, and `which_key`. [[1]](diffhunk://#diff-86a35ea659f5370d2544367bd1502ff199585d069aa608eba4bcece8d4381ce4L20-R40) [[2]](diffhunk://#diff-86a35ea659f5370d2544367bd1502ff199585d069aa608eba4bcece8d4381ce4L36-L51)