### PR TITLE
Update Lualine Mason status for Mason 2.0

### DIFF
--- a/nvim/lua/plugins/lualine.lua
+++ b/nvim/lua/plugins/lualine.lua
@@ -9,17 +9,16 @@ return {
 			local installed_packages = registry.get_installed_package_names()
 			local upgrades_available = false
 			local packages_outdated = 0
-			local function myCallback(success, _)
-				if success then
-					upgrades_available = true
-					packages_outdated = packages_outdated + 1
-				end
-			end
 
 			for _, pkg in pairs(installed_packages) do
 				local p = registry.get_package(pkg)
 				if p then
-					p:check_new_version(myCallback)
+					local latest_version = p:get_latest_version()
+					local installed_version = p:get_installed_version()
+					if installed_version ~= latest_version then
+						upgrades_available = true
+						packages_outdated = packages_outdated + 1
+					end
 				end
 			end
 


### PR DESCRIPTION
This pull request updates the logic in the `nvim/lua/plugins/lualine.lua` file to simplify how package version checks are performed. The most important change replaces a callback-based approach with a direct comparison of installed and latest package versions.
### Key change:
* Simplified the version-checking logic by replacing the callback-based `check_new_version` method with a direct comparison of `installed_version` and `latest_version`. This eliminates the need for a custom callback function and streamlines the process of determining outdated packages.