### PR TITLE
Praise should be very lazy

### DIFF
--- a/nvim/lua/plugins/praise.lua
+++ b/nvim/lua/plugins/praise.lua
@@ -1,5 +1,6 @@
 return {
 	"lseppala/praise.nvim",
+	event = "VeryLazy",
 	config = function()
 		require("praise").setup({
 			-- Optional: set a keymap


### PR DESCRIPTION
This pull request introduces a small change to the `praise.lua` plugin configuration. The change ensures the plugin is loaded lazily by adding the `event = "VeryLazy"` parameter.