### PR TITLE
Add 'Copilot Status' shortcut

### DIFF
--- a/nvim/lua/keys.lua
+++ b/nvim/lua/keys.lua
@@ -18,6 +18,7 @@ vim.keymap.set("n", "<s-t>", ":tabnew<cr>")
 
 -- Copilot
 vim.keymap.set("n", "<leader>cp", ":Copilot panel<cr>")
+vim.keymap.set("n", "<leader>cs", ":Copilot status<cr>")
 
 vim.keymap.set("n", "<leader>no", ":set nonu<cr>")
 vim.keymap.set("n", "<leader>nu", ":set nu<cr>")

--- a/nvim/lua/plugins/which-key.lua
+++ b/nvim/lua/plugins/which-key.lua
@@ -22,6 +22,7 @@ return {
 			{ "<leader>c", group = "Copilot & Path", icon = " " },
 			{ "<leader>cc", desc = "Copilot Chat", icon = "" },
 			{ "<leader>cf", desc = "Copy full path", icon = "" },
+			{ "<leader>cs", desc = "Copilot Status", icon = "" },
 			{ "<leader>cp", desc = "Copilot Panel", icon = "" },
 			{ "<leader>cr", desc = "Copy relative path", icon = "" },
 			{ "<leader>f", group = "Finding & Format" },


### PR DESCRIPTION
This pull request adds a new keybinding for checking the Copilot status in Neovim and updates the which-key plugin configuration to display this new shortcut in the keybinding helper. The main focus is improving Copilot integration and discoverability for users.