### PR TITLE
Lensline is hanging with large gitignores

### DIFF
--- a/nvim/lua/plugins/lensline.lua
+++ b/nvim/lua/plugins/lensline.lua
@@ -5,6 +5,9 @@ return {
 	config = function()
 		require("lensline").setup({
 			-- Profile definitions, first is default
+			limits = {
+				exclude_gitignored = false,
+			},
 			profiles = {
 				{
 					name = "basic",


### PR DESCRIPTION
This pull request makes a minor configuration adjustment to the Lensline plugin setup in `nvim/lua/plugins/lensline.lua`. The change modifies the behavior of the plugin regarding git-ignored files.