### PR TITLE
Add vite plus

### DIFF
--- a/fish/conf.d/vite-plus.fish
+++ b/fish/conf.d/vite-plus.fish
@@ -1,0 +1,2 @@
+# Vite+ bin (https://viteplus.dev)
+source "$HOME/.vite-plus/env.fish"

--- a/fish/conf.d/vite-plus.fish
+++ b/fish/conf.d/vite-plus.fish
@@ -1,2 +1,4 @@
 # Vite+ bin (https://viteplus.dev)
-source "$HOME/.vite-plus/env.fish"
+if test -d "$HOME/.vite-plus"
+    source "$HOME/.vite-plus/env.fish"
+end

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -12,8 +12,8 @@ set-option -g status-position top
 # ======= Prevent c-d existing from shell ==========
 set-environment -g 'IGNOREEOF' 3
 
-# Passthrough image support
-set -g allow-passthrough on
+# Passthrough OSC support (images, progress, etc.)
+set -g allow-passthrough all
 
 set -ga update-environment TERM
 set -ga update-environment TERM_PROGRAM
@@ -123,7 +123,6 @@ bind-key U display-popup -w 80% -h 80% -E -e "TMUX=#{socket_path},#{pid},#{sessi
 bind-key M-u display-popup -w 80% -h 80% -E -e "TMUX=#{socket_path},#{pid},#{session_id}" "~/.config/tmux/plugins/tpm/scripts/clean_plugins.sh && echo 'Done. Press ENTER to close.' && read"
 
 set -g status-style "bg=terminal"
-set -g allow-passthrough on
 set -g mouse on
 setw -g mode-keys vi
 


### PR DESCRIPTION
This pull request introduces configuration improvements for both the Fish shell and Tmux, focusing on enhanced environment setup and passthrough support.

Shell environment configuration:

* Added a new script to the Fish shell (`fish/conf.d/vite-plus.fish`) that automatically sources Vite+ environment variables if the `$HOME/.vite-plus` directory exists, streamlining setup for users of the Vite+ tool.

Tmux passthrough and configuration updates:

* Updated Tmux configuration to enable passthrough support for all OSC (Operating System Command) sequences, not just images, by changing the `allow-passthrough` setting from `on` to `all`. This allows Tmux to support images, progress bars, and other OSC features.
* Removed a redundant `allow-passthrough on` line later in the Tmux config to avoid conflicting or duplicate settings.