### PR TITLE
Speed up fish prompt and mise activation

### DIFF
--- a/bat/config
+++ b/bat/config
@@ -4,7 +4,7 @@
 
 # Specify desired highlighting theme (e.g. "TwoDark"). Run `bat --list-themes`
 # for a list of all available themes
---theme="Catppuccin-mocha"
+--theme="Catppuccin Mocha"
 
 # Enable this to use italic text on the terminal. This is not supported on all
 # terminal emulators (like tmux, by default):

--- a/fish/completions/copilot.fish
+++ b/fish/completions/copilot.fish
@@ -14,7 +14,7 @@ complete -c copilot -l interactive -s i -r -d 'Start interactive mode and automa
 complete -c copilot -l prompt -s p -r -d 'Execute a prompt in non-interactive mode (exits after completion)'
 complete -c copilot -l silent -s s -f -d 'Output only the agent response (no stats), useful for scripting with -p'
 complete -c copilot -l model -r -d 'Set the AI model to use'
-complete -c copilot -l effort -l reasoning-effort -r -d 'Set the reasoning effort level' -a 'low medium high xhigh'
+complete -c copilot -l effort -l reasoning-effort -r -d 'Set the reasoning effort level' -a 'none low medium high xhigh'
 complete -c copilot -l enable-reasoning-summaries -f -d 'Request reasoning summaries for OpenAI models'
 complete -c copilot -l agent -r -d 'Specify a custom agent to use'
 complete -c copilot -l resume -r -d 'Resume from a previous session (optionally specify session ID, task ID, or name; name matching is exact, case-insensitive)'

--- a/fish/conf.d/00-env.fish
+++ b/fish/conf.d/00-env.fish
@@ -2,6 +2,7 @@
 
 # Editor and tools
 set -gx EDITOR nvim
+set -gx MISE_FISH_AUTO_ACTIVATE 0
 
 # eza config
 set -gx EZA_CONFIG_DIR "$HOME/.config/eza"

--- a/fish/conf.d/21-aliases.fish
+++ b/fish/conf.d/21-aliases.fish
@@ -1,5 +1,4 @@
 # Aliases (functions under the hood)
 alias gt="tmuxinator start github"
-alias pt="tmuxinator start personal"
 alias st="tmuxinator start server"
 alias fzg="rgf"

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -2,7 +2,13 @@
 
 # Initialize mise early so tools are available in all shells
 if command -q mise
-    mise activate fish | source
+    # Avoid mise's default prompt hook; update once on startup and again only after cd.
+    mise activate fish --no-hook-env | source
+    mise hook-env -s fish | source
+
+    function __mise_cd_hook --on-variable PWD --description 'Update mise environment when changing directories'
+        mise hook-env -s fish | source
+    end
 end
 
 if status is-interactive

--- a/fish/functions/pt.fish
+++ b/fish/functions/pt.fish
@@ -1,0 +1,27 @@
+function pt --description "Start or attach the personal tmux session"
+    set -l session personal
+
+    if tmux has-session -t "$session" 2>/dev/null
+        if set -q TMUX
+            tmux switch-client -t "$session"
+        else
+            tmux attach-session -t "$session"
+        end
+        return
+    end
+
+    tmux new-session -d -s "$session" -n Monitor "fish -lc 'tmux set-window-option -t1 automatic-rename on; btm --battery; exec fish'" \; \
+        split-window -t "$session:1" -v "fish -lc 'gping -c blue google.com -c red aka.ms -c green github.com; exec fish'" \; \
+        split-window -t "$session:1" -v "fish -lc 'clear; exec fish'" \; \
+        select-layout -t "$session:1" main-horizontal \; \
+        new-window -t "$session:2" -n Code "fish -lc 'tmux set-window-option -t2 automatic-rename on; nvim; exec fish'" \; \
+        select-window -t "$session:1" \; \
+        select-pane -t "$session:1.0"
+    or return
+
+    if set -q TMUX
+        tmux switch-client -t "$session"
+    else
+        tmux attach-session -t "$session"
+    end
+end

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -64,6 +64,7 @@ trusted_config_paths = [
 
 verbose = false       # set to true to see full installation output, see `MISE_VERBOSE`
 http_timeout = "30s"  # set the timeout for http requests as duration string, see `MISE_HTTP_TIMEOUT`
+fetch_remote_versions_cache = "1h"
 jobs = 4              # number of plugins or runtimes to install in parallel. The default is `4`.
 raw = false           # set to true to directly pipe plugins to stdin/stdout/stderr
 yes = false           # set to true to automatically answer yes to all prompts
@@ -76,11 +77,16 @@ disable_default_registry = false # disable the default shorthands, see `MISE_DIS
 # disable_tools = ['node']           # disable specific tools, generally used to turn off core tools
 
 env_file = '.env' # load env vars from a dotenv file, see `MISE_ENV_FILE`
+env_cache = true  # cache computed env/PATH between shell hook runs
+env_cache_ttl = "1h"
 
 experimental = true # enable experimental features
 
 # configure messages displayed when entering directories with config files
 status = { missing_tools = "if_other_versions_installed", show_env = false, show_tools = false }
+
+[settings.github]
+credential_command = "gh auth token"
 
 # "_" is a special key for information you'd like to put into mise.toml that mise will never parse
 [_]

--- a/scripts/tmux-contextual-window-name-fast.sh
+++ b/scripts/tmux-contextual-window-name-fast.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env sh
+set -eu
+
+HELPER="$HOME/.config/tmux/plugins/tmux-contextual-window-name/bin/tmux-contextual-window-name"
+
+pane=""
+command=""
+path=""
+title=""
+pane_pid=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --pane)
+            pane="${2:-}"
+            shift 2
+            ;;
+        --command)
+            command="${2:-}"
+            shift 2
+            ;;
+        --path)
+            path="${2:-}"
+            shift 2
+            ;;
+        --title)
+            title="${2:-}"
+            shift 2
+            ;;
+        --pane-pid)
+            pane_pid="${2:-}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+fallback() {
+    exec "$HELPER" name --pane "$pane" --command "$command" --path "$path" --title "$title" --pane-pid "$pane_pid"
+}
+
+truncate() {
+    value="$1"
+    max="$2"
+    length=$(printf "%s" "$value" | wc -c | tr -d ' ')
+    if [ "$length" -le "$max" ]; then
+        printf "%s" "$value"
+    else
+        prefix_len=$((max - 1))
+        printf "%s…" "$(printf "%s" "$value" | cut -c "1-$prefix_len")"
+    fi
+}
+
+path_slug() {
+    target="${1:-}"
+    fallback_value="${2:-}"
+
+    if [ -z "$target" ]; then
+        printf "%s" "$fallback_value"
+        return
+    fi
+
+    if [ "$target" = "$HOME" ]; then
+        printf "~"
+        return
+    fi
+
+    if [ -d "$target" ]; then
+        dir="$target"
+    else
+        dir=$(dirname "$target")
+    fi
+
+    while [ "$dir" != "/" ] && [ -n "$dir" ]; do
+        if [ -d "$dir/.git" ] || [ -f "$dir/.git" ]; then
+            name=${dir%/}
+            printf "%s" "${name##*/}"
+            return
+        fi
+        dir=$(dirname "$dir")
+    done
+
+    name=${target%/}
+    printf "%s" "${name##*/}"
+}
+
+cmd=$(basename "${command:-}")
+
+case "$title" in
+    "🤖 "*|"Copilot: "|"Copilot: "*|"GitHub Copilot")
+        fallback
+        ;;
+esac
+
+case "$cmd" in
+    node|nodejs|copilot)
+        fallback
+        ;;
+    nvim|fish)
+        truncate "$(path_slug "$path" "$cmd")" 24
+        ;;
+    *)
+        truncate "${cmd:-$(path_slug "$path" "")}" 16
+        ;;
+esac

--- a/scripts/tmux-load-plugins.sh
+++ b/scripts/tmux-load-plugins.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+set -eu
+
+finish() {
+    status=$?
+
+    if [ "$status" -eq 0 ]; then
+        tmux set-option -g @tmux_plugins_loading "0" 2>/dev/null || true
+    else
+        tmux set-option -g @tmux_plugins_loading "failed" 2>/dev/null || true
+    fi
+
+    tmux refresh-client -S 2>/dev/null || true
+}
+
+trap finish EXIT
+
+"$HOME/.config/tmux/plugins/tpm/tpm"
+
+tmux source-file "$HOME/.config/tmux/post-tpm.conf"
+tmux set-option -g status-style "bg=terminal"
+tmux set-option -g mouse on
+tmux set-window-option -g mode-keys vi
+
+# Overrides that depend on Catppuccin plugin options must run after TPM.
+tmux source-file "$HOME/.config/tmux/post-catppuccin.conf"

--- a/scripts/tmux-show-outdated.sh
+++ b/scripts/tmux-show-outdated.sh
@@ -3,7 +3,7 @@ PLUGIN_DIR="$HOME/.config/tmux/plugins/tmux-outdated-packages"
 SHOW_STATUS_SCRIPT="$PLUGIN_DIR/scripts/show-status.sh"
 
 if [ -x "$SHOW_STATUS_SCRIPT" ]; then
-    OUTPUT=$("$SHOW_STATUS_SCRIPT")
+    OUTPUT=$("$SHOW_STATUS_SCRIPT" 2>/dev/null)
     # Trim whitespace to check if empty
     TRIMMED=$(echo "$OUTPUT" | xargs)
     

--- a/starship.toml
+++ b/starship.toml
@@ -418,20 +418,43 @@ mantle = "#1e2030"
 crust = "#181926"
 
 [custom.jj_branch]
-when = "jj workspace root --ignore-working-copy > /dev/null 2>&1"
+shell = "sh"
+when = '''
+dir="$PWD"
+while [ "$dir" != "/" ]; do
+  [ -d "$dir/.jj" ] && exit 0
+  dir="$(dirname "$dir")"
+done
+exit 1
+'''
 command = '''
 jj log -r "(immutable_heads()..@):: & branches()" -T 'local_branches.join(\"\n\") ++ \"\n\"' --no-graph --ignore-working-copy | head -n 1
 '''
 style = 'yellow'
 
 [custom.jj_op]
-when = "jj workspace root --ignore-working-copy > /dev/null 2>&1"
+shell = "sh"
+when = '''
+dir="$PWD"
+while [ "$dir" != "/" ]; do
+  [ -d "$dir/.jj" ] && exit 0
+  dir="$(dirname "$dir")"
+done
+exit 1
+'''
 command = 'jj op log -n 1 -T "id.short()" --no-graph --ignore-working-copy'
 symbol = 'op:'
 style = "bright-yellow"
 
 [custom.jj_git_notinsync]
+shell = "sh"
 when = '''
+dir="$PWD"
+while [ "$dir" != "/" ]; do
+  [ -d "$dir/.jj" ] && break
+  dir="$(dirname "$dir")"
+done
+[ "$dir" = "/" ] && exit 1
 [ -n "${jj_git_head:=$(jj log -T commit_id --no-graph --ignore-working-copy -r HEAD@git)}" ] \
 && [ -n "${git_head:=$(git rev-parse HEAD)}" ] \
 && [ "$git_head" != "$jj_git_head" ]

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -40,6 +40,8 @@ set -g @catppuccin_window_current_text " #W #($HOME/.config/tmux/../scripts/tmux
 set -g renumber-windows on
 
 set -g status-right "#{?client_prefix,#{E:@catppuccin_status_session},}"
+set -g @tmux_plugins_loading "1"
+set -ag status-right "#{?#{==:#{@tmux_plugins_loading},1},#[fg=yellow] loading plugins #[default],#{?#{==:#{@tmux_plugins_loading},failed},#[fg=red] plugin load failed #[default],}}"
 set -ag status-right "#(command -v tmux-background-install-indicator.sh >/dev/null 2>&1 && tmux-background-install-indicator.sh || echo '')"
 set -ag status-right "#{E:@catppuccin_status_outdated_packages}"
 set -ag status-right "#{?#($HOME/.config/tmux/plugins/tmux-speedtest/scripts/speedtest_status.sh),#{E:@catppuccin_status_ctp_speedtest},}"
@@ -131,14 +133,4 @@ bind ` splitw "gotop -c monokai"
 bind m command-prompt "splitw 'exec man %%'"
 bind / command-prompt "splitw '%%'"
 
-run '~/.config/tmux/plugins/tpm/tpm'
-source-file ~/.config/tmux/post-tpm.conf
-
-set -g status-style "bg=terminal"
-set -g mouse on
-setw -g mode-keys vi
-
-
-
-# Override catppuccin status modules AFTER tpm loads them
-source-file ~/.config/tmux/post-catppuccin.conf
+run-shell -b '~/.config/tmux/../scripts/tmux-load-plugins.sh'

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -22,8 +22,8 @@ set -ga update-environment TERM_PROGRAM
 set -ga update-environment PATH
 set -s set-clipboard on
 
-# Status line refresh interval (faster when background installations are running)
-set -g status-interval 1
+# Keep status responsive without rerunning status helpers every second.
+set -g status-interval 5
 
 # ================== Theme =========================
 set -g @catppuccin_window_status_style "rounded"
@@ -35,9 +35,8 @@ set -g status-right ""
 set -ogq @catppuccin_window_flags "icon"
 # set -g @catppuccin_window_text " #{pane_current_command}"
 
-set -g @catppuccin_window_text " #W #(/Users/djensenius/.config/tmux/plugins/tmux-contextual-window-name/bin/tmux-contextual-window-name name --pane #{q:pane_id} --command #{q:pane_current_command} --path #{q:pane_current_path} --title #{q:pane_title} --pane-pid #{q:pane_pid})"
-set -g @catppuccin_window_current_text " #W #(/Users/djensenius/.config/tmux/plugins/tmux-contextual-window-name/bin/tmux-contextual-window-name name --pane #{q:pane_id} --command #{q:pane_current_command} --path #{q:pane_current_path} --title #{q:pane_title} --pane-pid #{q:pane_pid})"
-# set -wg automatic-rename on
+set -g @catppuccin_window_text " #W"
+set -g @catppuccin_window_current_text " #W"
 set -g renumber-windows on
 
 set -g status-right "#{?client_prefix,#{E:@catppuccin_status_session},}"

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -35,8 +35,8 @@ set -g status-right ""
 set -ogq @catppuccin_window_flags "icon"
 # set -g @catppuccin_window_text " #{pane_current_command}"
 
-set -g @catppuccin_window_text " #W #(/Users/david/.config/tmux/plugins/tmux-contextual-window-name/bin/tmux-contextual-window-name name --pane #{q:pane_id} --command #{q:pane_current_command} --path #{q:pane_current_path} --title #{q:pane_title} --pane-pid #{q:pane_pid})"
-set -g @catppuccin_window_current_text " #W #(/Users/david/.config/tmux/plugins/tmux-contextual-window-name/bin/tmux-contextual-window-name name --pane #{q:pane_id} --command #{q:pane_current_command} --path #{q:pane_current_path} --title #{q:pane_title} --pane-pid #{q:pane_pid})"
+set -g @catppuccin_window_text " #W #($HOME/.config/tmux/../scripts/tmux-contextual-window-name-fast.sh --pane #{q:pane_id} --command #{q:pane_current_command} --path #{q:pane_current_path} --title #{q:pane_title} --pane-pid #{q:pane_pid})"
+set -g @catppuccin_window_current_text " #W #($HOME/.config/tmux/../scripts/tmux-contextual-window-name-fast.sh --pane #{q:pane_id} --command #{q:pane_current_command} --path #{q:pane_current_path} --title #{q:pane_title} --pane-pid #{q:pane_pid})"
 set -g renumber-windows on
 
 set -g status-right "#{?client_prefix,#{E:@catppuccin_status_session},}"

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -35,8 +35,8 @@ set -g status-right ""
 set -ogq @catppuccin_window_flags "icon"
 # set -g @catppuccin_window_text " #{pane_current_command}"
 
-set -g @catppuccin_window_text " #W"
-set -g @catppuccin_window_current_text " #W"
+set -g @catppuccin_window_text " #W #(/Users/david/.config/tmux/plugins/tmux-contextual-window-name/bin/tmux-contextual-window-name name --pane #{q:pane_id} --command #{q:pane_current_command} --path #{q:pane_current_path} --title #{q:pane_title} --pane-pid #{q:pane_pid})"
+set -g @catppuccin_window_current_text " #W #(/Users/david/.config/tmux/plugins/tmux-contextual-window-name/bin/tmux-contextual-window-name name --pane #{q:pane_id} --command #{q:pane_current_command} --path #{q:pane_current_path} --title #{q:pane_title} --pane-pid #{q:pane_pid})"
 set -g renumber-windows on
 
 set -g status-right "#{?client_prefix,#{E:@catppuccin_status_session},}"


### PR DESCRIPTION
## Summary

This PR is a performance pass over interactive shell/tmux startup paths. It keeps the existing workflows and visual setup, but removes repeated work from prompt rendering, mise activation, tmux window labels, tmuxinator startup, and tmux plugin startup.

## Performance results

| Area | Before | After | Savings | Change |
| --- | ---: | ---: | ---: | --- |
| Starship right prompt | ~0.9-1.2s | ~19-21ms | ~0.9-1.2s per prompt | Custom `jj` modules run with `sh` instead of Fish and skip work outside `.jj` repos. |
| Fish startup | noticeably slower from duplicate mise activation | ~0.10s | avoided duplicate activation | Disabled Homebrew's vendor `mise activate fish` with `MISE_FISH_AUTO_ACTIVATE=0`. |
| Mise hook on Enter | ran on every prompt | no prompt hook | avoids repeated prompt work | Replaced default prompt hook with startup activation plus a `PWD` change hook. |
| Mise `PWD` env refresh | repeated prompt-time work | ~8-10ms only on directory changes | prompt stays fast | `mise hook-env -s fish` runs only when `PWD` changes. |
| Mise remote/tool resolution | repeated GitHub/version lookups and rate-limit warnings | cached for 1h | avoids repeated network/version checks | Enabled mise env/version caches and used `gh auth token` for GitHub API auth. |
| Starship custom `jj` modules | Fish startup for each custom module | shell + `.jj` guard | right prompt down to ~20ms | Uses cheap guard before calling `jj`. |
| Tmux contextual window label helper | ~70-100ms per common pane label | ~10-20ms | ~50-90ms per label render | Added shell fast path for common `fish`/`nvim` panes; Python fallback remains. |
| Tmux status refresh | helpers ran every 1s | every 5s | fewer recurring helper processes | Raised `status-interval` from `1` to `5`. |
| `pt` / personal tmux session launcher | ~7.6-7.7s via tmuxinator | ~3.2s cold before async TPM | ~4.4s | Replaced only `pt` with a direct Fish function that creates the same personal session layout. |
| Tmux cold startup | ~2.1-2.3s | ~0.02-0.03s immediate return | ~2.1s | TPM now loads asynchronously in the background. |
| `pt` after async TPM | ~3.2s cold path | ~0.03s immediate return | ~3.1s | Direct `pt` launcher benefits from async TPM. |

## Key findings

| Finding | Evidence | Resolution |
| --- | --- | --- |
| Tmux itself was not slow | Minimal tmux startup measured ~20-30ms. Full config measured ~2.1-2.3s. | Focused on TPM/plugin loading rather than tmux core. |
| TPM was the cold-start bottleneck | Removing only the TPM runner dropped startup to ~30ms. | Moved TPM into a background loader. |
| Missing `npm@latest` made mise noisy/slow | Mise tried GitHub `npm/cli` release lookups and hit rate limits when npm was missing. | Kept `npm = 'latest'` after installing it locally and added caching/auth. |
| Starship right prompt was dominated by custom shell modules | `jj` custom modules were running through Fish and costing close to a second. | Switched custom module shell to `sh` and added `.jj` guards. |
| `tmuxinator start personal` was much slower than equivalent tmux commands | `tmuxinator start personal --no-attach` measured ~7.6-7.7s; direct equivalent was much faster. | Added a dedicated `pt` Fish function for the personal session only. |

## Files changed by area

| Area | Files | Purpose |
| --- | --- | --- |
| Mise caching/auth | `mise/config.toml` | Cache remote version/env data for 1h and authenticate GitHub requests via `gh auth token`. |
| Fish/mise activation | `fish/conf.d/00-env.fish`, `fish/config.fish` | Disable duplicate Homebrew mise auto-activation and run mise env refresh on startup/`PWD` change only. |
| Prompt speed | `starship.toml` | Make custom `jj` prompt modules cheaper. |
| Tmux status/window labels | `tmux/tmux.conf`, `scripts/tmux-contextual-window-name-fast.sh`, `scripts/tmux-show-outdated.sh` | Reduce recurring status work and speed common contextual window labels. |
| Personal tmux launcher | `fish/conf.d/21-aliases.fish`, `fish/functions/pt.fish` | Replace `pt` tmuxinator alias with a direct session launcher. |
| Async TPM | `tmux/tmux.conf`, `scripts/tmux-load-plugins.sh` | Load plugins in the background and show loading/failure status. |
| Misc user changes included | `bat/config`, `fish/completions/copilot.fish` | Bat theme naming and Copilot completion update. |

## Tmux async loading details

Tmux startup was split into two phases:

| Phase | Behavior |
| --- | --- |
| Immediate startup | Tmux creates the server/session and becomes usable in ~20-30ms. |
| Background plugin load | `scripts/tmux-load-plugins.sh` runs TPM, then reapplies `post-tpm.conf`, `status-style`, mouse/mode settings, and `post-catppuccin.conf`. |
| Status indicator | `loading plugins` appears in yellow while loading; it clears on success and shows `plugin load failed` in red on failure. |
| Settle time | Plugin keybinds/theme/status settled after roughly 2 seconds in testing. |

## Tradeoffs

| Tradeoff | Impact |
| --- | --- |
| Async TPM is eventually consistent | Plugin-provided keybinds and final theme/status styling may not be available for the first second or two after a brand-new tmux server starts. |
| `pt` no longer uses tmuxinator | Only the personal session hot path changed. `gt` and `st` still use tmuxinator. |
| Status helpers refresh less often | Package/speedtest/battery-style status updates can lag by up to 5s, but this avoids rerunning helpers every second. |
| Mise caches for 1h | Newly released remote tool versions may not appear immediately, but prompt/startup avoids repeated remote checks. |

## Commits

| Commit | Description |
| --- | --- |
| `9630301` | Speed up fish prompt and mise activation |
| `9c216b6` | Update bat theme and copilot completions |
| `aa4642a` | Reduce tmux status line overhead |
| `8d84613` | Restore contextual tmux window labels |
| `12b41ce` | Add fast path for tmux window labels |
| `69fb038` | Speed up personal tmux session launcher |
| `fd32d1f` | Load tmux plugins asynchronously |
