### PR TITLE
Fix vite check

### DIFF
--- a/fish/conf.d/vite-plus.fish
+++ b/fish/conf.d/vite-plus.fish
@@ -1,4 +1,4 @@
 # Vite+ bin (https://viteplus.dev)
-if test -d "$HOME/.vite-plus"
+if test -d "$HOME/.vite-plus" && test -f "$HOME/.vite-plus/env.fish"
     source "$HOME/.vite-plus/env.fish"
 end


### PR DESCRIPTION
This pull request makes a minor improvement to the `fish/conf.d/vite-plus.fish` startup script by ensuring that the script only sources the `env.fish` file if it actually exists, preventing potential errors if the file is missing.

* Only source `env.fish` if it exists in the `.vite-plus` directory to avoid errors during shell initialization.