### PR TITLE
fix: move mise security settings to fish env

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -1,5 +1,12 @@
 # Interactive-only setup. Everything else lives in conf.d/*.fish
 
+# Security-sensitive mise settings must come from env because ~/.config/mise
+# is symlinked into this repo and mise treats the real path as non-global.
+set -gx MISE_TRUSTED_CONFIG_PATHS "$HOME/Developer:$HOME/Code:/workspaces"
+set -gx MISE_GITHUB_CREDENTIAL_COMMAND "gh auth token"
+set -gx MISE_PARANOID false
+set -gx MISE_YES false
+
 # Initialize mise early so tools are available in all shells
 if command -q mise
     # Avoid mise's default prompt hook; update once on startup and again only after cd.

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -56,23 +56,14 @@ always_keep_install = false         # deleted on failure by default
 # (note: this isn't currently implemented but there are plans to add it: https://github.com/jdx/mise/discussions/6735)
 plugin_autoupdate_last_check_duration = '1 week' # set to 0 to disable updates
 
-# config files with these prefixes will be trusted by default
-trusted_config_paths = [
-    '~/Developer',
-    '~/Code',
-    '/workspaces',
-]
-
 verbose = false       # set to true to see full installation output, see `MISE_VERBOSE`
 http_timeout = "30s"  # set the timeout for http requests as duration string, see `MISE_HTTP_TIMEOUT`
 fetch_remote_versions_cache = "1h"
 jobs = 4              # number of plugins or runtimes to install in parallel. The default is `4`.
 raw = false           # set to true to directly pipe plugins to stdin/stdout/stderr
-yes = false           # set to true to automatically answer yes to all prompts
 
 not_found_auto_install = true # see MISE_NOT_FOUND_AUTO_INSTALL
 task_output = "prefix" # see Tasks Runner for more information
-paranoid = false       # see MISE_PARANOID
 
 disable_default_registry = false # disable the default shorthands, see `MISE_DISABLE_DEFAULT_SHORTHANDS`
 # disable_tools = ['node']           # disable specific tools, generally used to turn off core tools
@@ -85,9 +76,6 @@ experimental = true # enable experimental features
 
 # configure messages displayed when entering directories with config files
 status = { missing_tools = "if_other_versions_installed", show_env = false, show_tools = false }
-
-[settings.github]
-credential_command = "gh auth token"
 
 # "_" is a special key for information you'd like to put into mise.toml that mise will never parse
 [_]


### PR DESCRIPTION
## Summary
- move mise security-sensitive settings out of the symlinked repo TOML config
- export those settings from fish before mise initializes
- keep mise tool/version config in mise/config.toml

## Validation
- yamllint on tracked YAML files
- tomllint on tracked TOML files
- fish --no-execute on tracked fish files
- fish_indent formatting check on tracked fish files
- actionlint