### PR TITLE
fix: add pkl eval linter to catch diagnostics pkl-lsp misses

### DIFF
--- a/fish/conf.d/53-github-copilot-cli.fish
+++ b/fish/conf.d/53-github-copilot-cli.fish
@@ -63,5 +63,5 @@ alias 'gh!'='__copilot_gh-assist'
 
 # Generate copilot completions on first use (if CLI is installed)
 if command -q copilot; and not test -f ~/.config/fish/completions/copilot.fish
-    copilot completion fish > ~/.config/fish/completions/copilot.fish 2>/dev/null
+    copilot completion fish >~/.config/fish/completions/copilot.fish 2>/dev/null
 end

--- a/nvim/lua/plugins/lualine.lua
+++ b/nvim/lua/plugins/lualine.lua
@@ -176,7 +176,7 @@ return {
 							separator = " ",
 						},
 						on_click = function()
-							vim.cmd(":LspInfo")
+							vim.cmd(":checkhealth vim.lsp")
 						end,
 					},
 				},
@@ -194,7 +194,7 @@ return {
 					{
 						"filetype",
 						on_click = function()
-							vim.cmd(":LspInfo")
+							vim.cmd(":checkhealth vim.lsp")
 						end,
 						cond = function()
 							return vim.bo.filetype and #vim.bo.filetype > 0

--- a/nvim/lua/plugins/nvim-lint.lua
+++ b/nvim/lua/plugins/nvim-lint.lua
@@ -9,6 +9,7 @@ return {
 
 		lint.linters_by_ft = {
 			fish = { "fish" },
+			pkl = { "pkl" },
 			python = { "pylint" },
 			javascript = { "eslint_d" },
 			javascriptreact = { "eslint_d" },
@@ -18,6 +19,99 @@ return {
 			svelte = { "eslint_d" },
 			typescript = { "eslint_d" },
 			typescriptreact = { "eslint_d" },
+		}
+
+		-- Pkl linter: uses `pkl eval` to catch errors the LSP misses
+		-- (e.g. missing required properties — apple/pkl-lsp#103).
+		-- Since we always evaluate the current buffer, every reported error
+		-- is relevant: attach it to a matching source line in this buffer if
+		-- there is one, otherwise to line 1 with the render path for context.
+		lint.linters.pkl = {
+			name = "pkl",
+			cmd = "pkl",
+			stdin = false,
+			args = { "eval" },
+			stream = "stderr",
+			ignore_exitcode = true,
+			parser = function(output, bufnr)
+				local diagnostics = {}
+				if not output or output == "" then
+					return diagnostics
+				end
+				local bufpath = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":p")
+				local lines = vim.split(output, "\n", { plain = true })
+
+				local blocks = {}
+				local cur
+				local pending
+				for _, line in ipairs(lines) do
+					if line:match("^.- Pkl Error .-$") and line:match("Pkl Error") then
+						cur = { msg = nil, locs = {}, render = nil }
+						pending = nil
+						table.insert(blocks, cur)
+					elseif cur then
+						if not cur.msg and vim.trim(line) ~= "" then
+							cur.msg = vim.trim(line)
+						end
+						local gutter = line:match("^(%d+) | ")
+						if gutter then
+							pending = { num = tonumber(gutter), prefix = #gutter + 3 }
+						end
+						local caret = line:match("^(%s*%^+)%s*$")
+						if caret and pending then
+							pending.caret_start = (line:find("%^") or 1)
+						end
+						local file, atline = line:match("at .- %(file://([^,]+), line (%d+)%)")
+						if file then
+							local loc = { file = file, line = tonumber(atline) }
+							if pending and pending.num == loc.line then
+								loc.col = math.max((pending.caret_start or 1) - pending.prefix - 1, 0)
+							end
+							table.insert(cur.locs, loc)
+							pending = nil
+						end
+						local rpath = line:match("rendering path `(.-)` of module")
+						if rpath then
+							cur.render = rpath
+						end
+					end
+				end
+
+				for _, block in ipairs(blocks) do
+					local msg = block.msg or "Pkl error"
+					-- Prefer a source location inside the current buffer.
+					local here
+					for _, loc in ipairs(block.locs) do
+						if vim.fn.resolve(loc.file) == bufpath then
+							here = loc
+							break
+						end
+					end
+					if here then
+						table.insert(diagnostics, {
+							lnum = here.line - 1,
+							col = here.col or 0,
+							severity = vim.diagnostic.severity.ERROR,
+							message = msg,
+							source = "pkl",
+						})
+					else
+						-- Error originates in an imported/amended file; surface it
+						-- on line 1 with the render path so it isn't lost.
+						if block.render then
+							msg = block.render .. ": " .. msg
+						end
+						table.insert(diagnostics, {
+							lnum = 0,
+							col = 0,
+							severity = vim.diagnostic.severity.ERROR,
+							message = msg,
+							source = "pkl",
+						})
+					end
+				end
+				return diagnostics
+			end,
 		}
 
 		-- Use system rubocop (from mise) instead of Mason's version

--- a/nvim/lua/plugins/pkl.lua
+++ b/nvim/lua/plugins/pkl.lua
@@ -11,7 +11,7 @@ return {
 	config = function()
 		vim.g.pkl_neovim = {
 			start_command = { "pkl-lsp" },
-			pkl_cli_path = "pkl",
+			pkl_cli_path = vim.fn.exepath("pkl"),
 		}
 	end,
 }


### PR DESCRIPTION
## Summary

pkl-lsp 0.7.1 doesn't reliably publish diagnostics in neovim — notably it misses **missing required properties** (e.g. an unset `address` field whose `address.street` is then undefined; see [apple/pkl-lsp#103](https://github.com/apple/pkl-lsp/issues/103)). This adds a nvim-lint linter that runs `pkl eval` and parses its error output to fill that gap.

## Changes

- **`nvim/lua/plugins/nvim-lint.lua`**: New `pkl` linter using `pkl eval`. The parser:
  - Attaches in-buffer errors (e.g. type mismatches) to their exact line/col.
  - Surfaces errors reported at an imported/amended definition site on line 1 with the render path (e.g. `address.street: Tried to read property…`) so they aren't lost.
- **`nvim/lua/plugins/pkl.lua`**: Set `pkl_cli_path` to an absolute path via `vim.fn.exepath('pkl')` so the LSP resolves the mise-managed `pkl` binary.
- **`nvim/lua/plugins/lualine.lua`**: Switch the LSP click handler from `:LspInfo` to `:checkhealth vim.lsp` for more detailed LSP info.

## Testing

Verified in headless neovim against real `.pkl` files:
- Type mismatch (`y: Int = "str"`) → diagnostic at exact line/col (matches LSP).
- Missing required property → diagnostic on line 1 with render path (LSP misses this).

`stylua --check` passes.

## Notes

The LSP is kept for completions, hover, and goto-definition. When the next pkl-lsp release fixes diagnostics, the lint linter can be revisited to avoid duplicates.