### PR TITLE
Remove OSC94 tmux pludin, add wc26 config

### DIFF
--- a/tmux/tmux-nerd-font-window-name.yml
+++ b/tmux/tmux-nerd-font-window-name.yml
@@ -7,3 +7,4 @@ icons:
   "git:": ""
   mise: "󱌣"
   tail: 
+  worldcup26: "󰒸"

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -93,16 +93,16 @@ set -g @sessionx-bind 'o'
 set -g @floax-bind 'O'
 
 # ============== OSC 9;4 ==========================
-set -g @plugin 'djensenius/tmux-osc-9-4'
-set -g @osc94_enabled 'on'
-set -g @osc94_state_dir "$HOME/.local/state/tmux-osc-9-4"
-set -g @osc94_python_bin 'python3'
+# set -g @plugin 'djensenius/tmux-osc-9-4'
+# set -g @osc94_enabled 'on'
+# set -g @osc94_state_dir "$HOME/.local/state/tmux-osc-9-4"
+# set -g @osc94_python_bin 'python3'
 # Animated per-window progress flag (spinner for "thinking"). Fed into the
 # #{@osc94_flag} window option above by a small background daemon, which uses
 # refresh-client -S so it animates without re-running the status #() helpers.
-set -g @osc94_animate 'on'
-set -g @osc94_animate_fps '20'
-run-shell -b '~/.config/tmux/../scripts/tmux-osc94-animate.sh'
+# set -g @osc94_animate 'on'
+# set -g @osc94_animate_fps '20'
+# run-shell -b '~/.config/tmux/../scripts/tmux-osc94-animate.sh'
 
 # ============== Bell flag ========================
 # The Copilot CLI rings the bell when it needs feedback (approvals, questions)

--- a/worldcup26/config.toml
+++ b/worldcup26/config.toml
@@ -1,0 +1,24 @@
+# worldcup26 configuration
+#
+# On macOS this file is auto-loaded from ~/.config/worldcup26/config.toml.
+# (Set XDG_CONFIG_HOME to override the location on any platform.)
+
+# Favourite teams, by display name or abbreviation (case-insensitive).
+favorites = ["Canada", "Spain", "Argentina"]
+
+[provider]
+# Backend to use: "espn", "api-football", or "football-data".
+# ESPN requires no API key.
+kind = "espn"
+# api_football_key = "..."        # or env WORLDCUP26_API_FOOTBALL_KEY
+# football_data_key = "..."       # or env WORLDCUP26_FOOTBALL_DATA_KEY
+
+[ui]
+# Colour theme name.
+theme = "catppuccin-mocha"
+# Use Nerd Font glyphs for icons.
+nerd_fonts = true
+# Show national flags on the Live card when the terminal supports graphics.
+show_flags = true
+# Kickoff times: "local", "utc", or a fixed hour offset such as -4.
+timezone = "local"


### PR DESCRIPTION
This pull request introduces initial support for a new tool called `worldcup26`, including its configuration file, adds a corresponding icon for it in the tmux Nerd Font window name configuration, and comments out the OSC 9;4 plugin and related settings in the tmux configuration.

**New tool support and configuration:**

* Added a new configuration file `worldcup26/config.toml` with options for favorite teams, data provider selection, and UI preferences such as theme, icon fonts, and timezone.

**Tmux integration updates:**

* Added a Nerd Font icon for `worldcup26` in `tmux/tmux-nerd-font-window-name.yml` to support visual identification in tmux window names.
* Commented out the OSC 9;4 plugin and all related settings in `tmux.conf`, disabling animated per-window progress flags and OSC 9;4 features.