### PR TITLE
fix: restore arrow keys in tmux TUI apps

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -9,7 +9,11 @@ set-option -sa terminal-features ',xterm*:RGB'
 set-option -sa terminal-features ',xterm*:Tc'
 set-option -sa terminal-features ',xterm*:extkeys'
 set-option -g status-position top
-set -g extended-keys on
+# Use `always` (not `on`): keep full CSI-u modified-key support for nvim, but
+# force modifyOtherKeys mode 1 so unmodified arrows always stay standard even
+# if an app requests mode 2 (mode 2 re-encodes arrows as ESC[1;1A and breaks
+# them in nvim/TUIs on tmux 3.7).
+set -s extended-keys always
 set -g extended-keys-format csi-u
 
 # ======= Prevent c-d existing from shell ==========

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -283,8 +283,10 @@ config.window_frame = {
 -- Make URLs, commit SHAs, issue refs, etc. clickable
 config.hyperlink_rules = wezterm.default_hyperlink_rules()
 
--- Honor kitty keyboard protocol requests; tmux forwards them via extkeys.
-config.enable_kitty_keyboard = true
+-- Do NOT enable the kitty keyboard protocol. tmux does not speak it; when
+-- WezTerm negotiates it directly, arrow keys get mis-encoded for TUI apps
+-- (nvim, etc.) running inside tmux. tmux's own extkeys/CSI-u handling already
+-- covers modified keys. (Regression fixed before in "Fix arrow keys".)
 
 -- Quality-of-life
 config.scrollback_lines = 10000


### PR DESCRIPTION
## Problem

Arrow keys stopped working in nvim and other TUI apps running inside tmux.

## Root cause

`wezterm.lua` had `config.enable_kitty_keyboard = true`. WezTerm negotiates the kitty keyboard protocol directly, but tmux does not speak it, so arrow keys were mis-encoded for apps running inside tmux. This is a repeat of the regression previously fixed in the "Fix arrow keys" commit — the line was re-added minutes later in "Keep extended key support" with an incorrect rationale (tmux does *not* forward kitty keyboard via extkeys).

Additionally, with `extended-keys on`, tmux honored apps' request for modifyOtherKeys **mode 2** (`pane_key_mode = Ext 2`), which re-encodes unmodified arrows as `ESC[1;1A` — unrecognized by TUI terminfo.

## Fix

- **wezterm/wezterm.lua**: remove `enable_kitty_keyboard = true` (the primary culprit).
- **tmux/tmux.conf**: `extended-keys on` → `always`. Keeps full CSI-u modified-key support for nvim, but forces modifyOtherKeys mode 1 so unmodified arrows always stay standard even if an app requests mode 2.

Best-of-everything: modified keys (Ctrl/Shift/Meta) still reach nvim via CSI-u, while arrow keys work again.

## Testing

- Verified live: `tmux show-options -s extended-keys` → `always`.
- Requires fully quitting/reopening WezTerm (kitty-keyboard state is negotiated per session) and a fresh tmux pane.