### PR TITLE
Add atuin AI

### DIFF
--- a/atuin/config.toml
+++ b/atuin/config.toml
@@ -233,3 +233,6 @@ records = true
 
 [theme]
 name = "catppuccin-mocha-mauve"
+
+[ai]
+enabled = true


### PR DESCRIPTION
This pull request introduces a new `[ai]` configuration section to the `atuin/config.toml` file, enabling AI-related features by default.

Configuration updates:

* Added an `[ai]` section with `enabled = true` to `atuin/config.toml` to activate AI features.