### PR TITLE
Add herdr config mirroring the tmux setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Herdr is a terminal workspace manager for AI coding agents. Its config is a deli
 | --- | --- | --- |
 | `prefix` = `^a` | `prefix` = `ctrl+a` | config |
 | `prefix h/j/k/l` focus pane | same | config |
-| `prefix ^h/^j/^k/^l` resize 10 | same | `[[keys.command]]` → `herdr pane resize` |
+| `prefix ^h/^j/^k/^l` resize 10 | same | `[[keys.command]]` → `herdr pane resize --amount 0.05` (Herdr takes a split-ratio delta, not a cell count) |
 | `prefix ^u` / `^d` swap pane | same | `[[keys.command]]` → `herdr pane swap` |
 | `prefix \|` / `-` split | `prefix v` / `prefix \` / `prefix -` | config |
 | `prefix q` kill pane | same (detach moves to `prefix d`) | config |
@@ -255,7 +255,11 @@ silently:
 | [Television](https://github.com/alexpasmantier/television) 0.15+ | `termscope` — its build step installs this **via Homebrew**, so `brew` must be on `PATH` or the plugin install fails |
 | Clipboard command (`pbcopy` on macOS, `wl-copy` on Wayland, `xclip`/`xsel` on X11) | `herdr-pluck` |
 
-Re-run `./install.sh` to install or refresh every plugin, or do it manually:
+`install.sh` does **not** install Herdr itself. Once `herdr` is on `PATH`, re-running
+`./install.sh` installs or refreshes every plugin (`install` doubles as the update
+path, so a rerun pulls the latest revision). Without `herdr`, the script logs a warning
+and skips the plugin phase entirely — which is what happens in a fresh Codespace. To do
+it by hand:
 
 ```bash
 herdr plugin install paulbkim-dev/vim-herdr-navigation --yes

--- a/README.md
+++ b/README.md
@@ -92,7 +92,17 @@ For local installation, most configurations can be symlinked to your `~/.config`
    ~/.tmux/plugins/tpm/scripts/install_plugins.sh
    ```
 
-4. **Install required tools** (see [Applications](#applications) section for details)
+4. **Special setup for Herdr:**
+   Herdr keeps sockets, logs and its own managed plugin checkouts inside
+   `~/.config/herdr`, so link the individual pieces rather than the directory.
+   ```bash
+   mkdir -p ~/.config/herdr
+   ln -sf ~/.dotfiles/herdr/config.toml ~/.config/herdr/config.toml
+   ln -sfn ~/.dotfiles/herdr/scripts ~/.config/herdr/scripts
+   ```
+   Then install the plugins listed in the [herdr](#herdr) section below.
+
+5. **Install required tools** (see [Applications](#applications) section for details)
 
 See the [install.sh](install.sh) script for the complete automated setup process used in GitHub Codespaces.
 
@@ -100,7 +110,7 @@ See the [install.sh](install.sh) script for the complete automated setup process
 
 This dotfiles collection includes configurations for:
 
-- **🖥️ Terminal & Shell**: Fish shell with starship prompt, tmux multiplexer
+- **🖥️ Terminal & Shell**: Fish shell with starship prompt, tmux and herdr multiplexers
 - **📝 Editor**: Neovim with 46+ plugins for modern development ([details](nvim/README.md))
 - **🔍 Search & Navigation**: fzf, ripgrep, fd, eza, zoxide for enhanced file operations
 - **📊 Git Workflow**: lazygit, delta, gitsigns integration for visual git management
@@ -174,6 +184,73 @@ Ghostty is a fast, feature-rich terminal emulator built for performance and cust
 ### [gopod](https://github.com/djensenius/gopod)
 Gopod is a tool for making radio programs that are streaming online into podcasts.
 - **Directory**: `gopod/`
+
+### [herdr](https://herdr.dev)
+Herdr is a terminal workspace manager for AI coding agents. Its config is a deliberate mirror of `tmux/tmux.conf` — same `Ctrl+a` prefix, same Catppuccin Mocha palette, and the same muscle memory — so switching between the two costs nothing.
+- **Directory**: `herdr/`
+- **Files**: `herdr/config.toml`, popup helpers in `herdr/scripts/`
+- **Linking**: Herdr keeps live sockets, logs and session state in `~/.config/herdr`, and owns `~/.config/herdr/plugins` for its own managed checkouts, so the directory is *not* symlinked wholesale. `install.sh` links `config.toml` and `scripts/` individually.
+
+#### tmux → herdr keymap
+
+| tmux | herdr | Provided by |
+| --- | --- | --- |
+| `prefix` = `^a` | `prefix` = `ctrl+a` | config |
+| `prefix h/j/k/l` focus pane | same | config |
+| `prefix ^h/^j/^k/^l` resize 10 | same | `[[keys.command]]` → `herdr pane resize` |
+| `prefix ^u` / `^d` swap pane | same | `[[keys.command]]` → `herdr pane swap` |
+| `prefix \|` / `-` split | `prefix v` / `prefix \` / `prefix -` | config |
+| `prefix q` kill pane | same (detach moves to `prefix d`) | config |
+| `prefix p` / `n` previous/next window | same | config |
+| `prefix 1..9` select window | same | config |
+| `prefix F1` / `^b` toggle status | `prefix b` / `prefix F1` toggle sidebar | config |
+| `prefix \`` gotop | `prefix \`` btop | `[[keys.command]]` |
+| `prefix m` man prompt | same | `herdr/scripts/herdr-man-popup.sh` |
+| `prefix /` command prompt | same | `herdr/scripts/herdr-run-popup.sh` |
+| `<C-h/j/k/l>` vim-tmux-navigator | same | [vim-herdr-navigation](https://github.com/paulbkim-dev/vim-herdr-navigation) |
+| tmux-sessionx (`prefix o`) | same | [herdr-navigator](https://github.com/thanhdat77/herdr-navigator) |
+| tmux-floax (`prefix O`) | same | [herdr-floax](https://github.com/Tyru5/herdr-floax) |
+| tmux-which-key (`prefix space`) | same | [herdr-command-palette](https://github.com/JanTvrdik/herdr-command-palette) |
+| tmux-thumbs | `prefix y` | [herdr-pluck](https://github.com/rmarganti/herdr-pluck) |
+| tmux-fzf-url (`prefix u`) | `prefix u` links, `prefix U` files | [termscope](https://github.com/iurysza/termscope) |
+| tmux-yank, `set-clipboard on` | `copy_on_select` | config |
+| catppuccin/tmux | `[theme] name = "catppuccin"` | config |
+
+#### Status modules
+
+The tmux `status-right` modules (`battery_hearts`, tmux-outdated-packages, tmux-speedtest) are **not** ported. Herdr has no status bar, and its tab bar has no status region — the sidebar is the only surface that renders custom metadata tokens, which is nowhere near where tmux puts them. They stay tmux-only for now.
+
+#### Tab naming
+
+Herdr's native tab naming is used as-is. `ui.prompt_new_tab_name = true` asks for a name when a tab is created, and `prefix T` renames later. The tmux equivalents — [tmux-contextual-window-name](https://github.com/djensenius/tmux-contextual-window-name) and [tmux-nerd-font-window-name](https://github.com/joshmedeski/tmux-nerd-font-window-name) — are **not** ported; the tmux config's Copilot title special-case is unnecessary here because Herdr detects agents natively.
+
+#### Agent integrations
+
+Herdr detects GitHub Copilot CLI automatically — the agent shows up in the Agent sidebar with `idle`/`working`/`blocked` state via screen-manifest detection, with no setup. This replaces the tmux config's Copilot window-title special-case.
+
+The optional hook adds **native session identity**, which lets Herdr resume a Copilot pane with `copilot --resume=<id>` after a server restart:
+
+```bash
+herdr integration install copilot
+herdr integration status
+```
+
+It writes `~/.copilot/hooks/herdr-agent-state.sh` (or `$COPILOT_HOME`) and adds a `SessionStart` entry to `~/.copilot/settings.json`; the config directory must already exist. This is a manual, one-time step — `install.sh` does not do it. Undo with `herdr integration uninstall copilot`.
+
+The hook is not a state authority — Copilot's `idle`/`working`/`blocked` state always comes from screen detection, whether or not it is installed.
+
+#### Plugin prerequisites
+
+`herdr-floax` and `herdr-navigator` build with `cargo`; `termscope` needs `python3`. Re-run `./install.sh`, or install manually:
+
+```bash
+herdr plugin install paulbkim-dev/vim-herdr-navigation --yes
+herdr plugin install JanTvrdik/herdr-command-palette --yes
+herdr plugin install rmarganti/herdr-pluck --yes
+herdr plugin install Tyru5/herdr-floax --yes
+herdr plugin install thanhdat77/herdr-navigator --yes
+herdr plugin install iurysza/termscope --yes
+```
 
 ### [k9s](https://k9scli.io) ([repo](https://github.com/derailed/k9s))
 K9s is a terminal UI to interact with your Kubernetes clusters.
@@ -270,6 +347,7 @@ The `install.sh` script is designed to set up and configure a development enviro
   - `atuin`
   - `yazi`
   - `bottom`
+  - `herdr/config.toml`, `herdr/scripts`
 
 - If running within a GitHub Codespace, it links executables (e.g., `rubocop`, `srb`, `bundle`, `solargraph`, `safe-ruby`) to `/usr/local/bin` and updates locale settings.
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,21 @@ The hook is not a state authority — Copilot's `idle`/`working`/`blocked` state
 
 #### Plugin prerequisites
 
-`herdr-floax` and `herdr-navigator` build with `cargo`; `termscope` needs `python3`. Re-run `./install.sh`, or install manually:
+Install these before the plugins, since they are needed at build time or at
+runtime and a missing one either aborts the install or makes the bound key fail
+silently:
+
+| Requirement | Needed by |
+| --- | --- |
+| `cargo` (Rust toolchain) | `herdr-floax`, `herdr-navigator` — built from source |
+| `python3` (3.10+) | `termscope` |
+| `jq` | `vim-herdr-navigation`, `herdr-floax`, `jt.command-palette` |
+| `fzf` | `jt.command-palette` |
+| `fd` | `termscope` file picker |
+| [Television](https://github.com/alexpasmantier/television) 0.15+ | `termscope` — its build step installs this **via Homebrew**, so `brew` must be on `PATH` or the plugin install fails |
+| Clipboard command (`pbcopy` on macOS, `wl-copy` on Wayland, `xclip`/`xsel` on X11) | `herdr-pluck` |
+
+Re-run `./install.sh` to install or refresh every plugin, or do it manually:
 
 ```bash
 herdr plugin install paulbkim-dev/vim-herdr-navigation --yes

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -106,28 +106,34 @@ navigate_pane_right = "l"
 # ================ Custom commands =================
 # tmux: `bind ^k resizep -U 10` and friends. Herdr only ships a modal
 # resize mode, so the one-shot resizes are replayed through the CLI.
+#
+# NOTE: `--amount` is a split-ratio DELTA, not a cell count. Verified against
+# herdr 0.7.5: on a 54-column split sitting at ratio 0.5, `--amount 0.05` moves
+# it to 0.55, whereas passing a cell count such as 10 slams the split straight
+# to the 0.9 clamp. 0.05 is about tmux's 10 columns on a full-width terminal and
+# never saturates the split.
 [[keys.command]]
 key = "prefix+ctrl+k"
 type = "shell"
-command = "\"$HERDR_BIN_PATH\" pane resize --pane \"$HERDR_ACTIVE_PANE_ID\" --direction up --amount 10"
+command = "\"$HERDR_BIN_PATH\" pane resize --pane \"$HERDR_ACTIVE_PANE_ID\" --direction up --amount 0.05"
 description = "resize pane up"
 
 [[keys.command]]
 key = "prefix+ctrl+j"
 type = "shell"
-command = "\"$HERDR_BIN_PATH\" pane resize --pane \"$HERDR_ACTIVE_PANE_ID\" --direction down --amount 10"
+command = "\"$HERDR_BIN_PATH\" pane resize --pane \"$HERDR_ACTIVE_PANE_ID\" --direction down --amount 0.05"
 description = "resize pane down"
 
 [[keys.command]]
 key = "prefix+ctrl+h"
 type = "shell"
-command = "\"$HERDR_BIN_PATH\" pane resize --pane \"$HERDR_ACTIVE_PANE_ID\" --direction left --amount 10"
+command = "\"$HERDR_BIN_PATH\" pane resize --pane \"$HERDR_ACTIVE_PANE_ID\" --direction left --amount 0.05"
 description = "resize pane left"
 
 [[keys.command]]
 key = "prefix+ctrl+l"
 type = "shell"
-command = "\"$HERDR_BIN_PATH\" pane resize --pane \"$HERDR_ACTIVE_PANE_ID\" --direction right --amount 10"
+command = "\"$HERDR_BIN_PATH\" pane resize --pane \"$HERDR_ACTIVE_PANE_ID\" --direction right --amount 0.05"
 description = "resize pane right"
 
 # tmux: `bind ^u swapp -U` / `bind ^d swapp -D`.

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -1,0 +1,305 @@
+# Herdr — terminal workspace manager for AI coding agents.
+#
+# This config mirrors tmux/tmux.conf as closely as Herdr allows: same ctrl+a
+# prefix, same Catppuccin Mocha palette, and the same muscle memory for splits,
+# resizes, pickers and popups. Where tmux used a plugin, the equivalent is
+# either a Herdr setting, a [[keys.command]], or a plugin (see README.md).
+#
+# Reload after editing: herdr server reload-config
+# Validate:             herdr config check
+
+onboarding = false
+
+# ==================== Theme ======================
+# tmux uses catppuccin/tmux pinned to the Mocha flavour. Herdr's built-in
+# catppuccin theme is used as-is, with no colour overrides.
+[theme]
+name = "catppuccin"
+
+# ==================== Terminal ===================
+[terminal]
+# macOS login shells so mise/homebrew PATH setup runs, matching a tmux pane.
+shell_mode = "auto"
+new_cwd = "follow"
+
+# ==================== UI =========================
+[ui]
+# tmux draws pane borders with the catppuccin theme; keep parity.
+pane_borders = true
+pane_gaps = true
+show_agent_labels_on_pane_borders = true
+
+# `set -s set-clipboard on` + tmux-yank: selecting text copies it.
+copy_on_select = true
+mouse_capture = true
+mouse_scroll_lines = 3
+
+# tmux hides nothing, but a single-tab workspace has no useful tab row.
+hide_tab_bar_when_single_tab = false
+
+sidebar_width = 30
+sidebar_min_width = 20
+sidebar_max_width = 40
+sidebar_collapsed_mode = "compact"
+
+confirm_close = true
+prompt_new_tab_name = true
+prompt_new_workspace_name = false
+agent_panel_sort = "spaces"
+
+# ==================== Keys =======================
+# tmux: `set -g prefix ^a` / `unbind ^b`.
+[keys]
+prefix = "ctrl+a"
+
+# --- Session / global ---
+help = "prefix+?"                     # replaces tmux-which-key
+settings = "prefix+s"
+detach = "prefix+d"                   # tmux detach-client; frees prefix+q below
+reload_config = "prefix+shift+r"
+open_notification_target = "prefix+shift+m"  # moved off prefix+o (sessionx)
+
+# --- Workspaces (tmux sessions) ---
+workspace_picker = "prefix+w"
+goto = "prefix+g"
+new_workspace = "prefix+shift+n"
+new_worktree = "prefix+shift+g"
+rename_workspace = "prefix+shift+w"
+close_workspace = "prefix+shift+d"
+switch_workspace = "prefix+shift+1..9"
+
+# --- Tabs (tmux windows) ---
+new_tab = "prefix+c"
+rename_tab = "prefix+shift+t"
+previous_tab = "prefix+p"             # tmux: `bind p previous-window`
+next_tab = "prefix+n"
+switch_tab = "prefix+1..9"            # tmux base-index 1
+close_tab = "prefix+shift+x"
+
+# --- Panes ---
+# tmux-pain-control: prefix+h/j/k/l focus, prefix+\ and prefix+- split.
+focus_pane_left = "prefix+h"
+focus_pane_down = "prefix+j"
+focus_pane_up = "prefix+k"
+focus_pane_right = "prefix+l"
+cycle_pane_next = "prefix+tab"
+cycle_pane_previous = "prefix+shift+tab"
+split_vertical = ["prefix+v", "prefix+backslash"]
+split_horizontal = "prefix+minus"
+close_pane = "prefix+q"               # tmux: `bind q killp`
+zoom = "prefix+z"
+resize_mode = "prefix+r"
+rename_pane = "prefix+shift+p"
+edit_scrollback = "prefix+e"
+
+# tmux: `bind F1 set status` and `bind ^b set-option -g status`.
+toggle_sidebar = ["prefix+b", "prefix+f1"]
+
+# --- Navigate mode ---
+navigate_workspace_up = "up"
+navigate_workspace_down = "down"
+navigate_pane_left = "h"
+navigate_pane_down = "j"
+navigate_pane_up = "k"
+navigate_pane_right = "l"
+
+# ================ Custom commands =================
+# tmux: `bind ^k resizep -U 10` and friends. Herdr only ships a modal
+# resize mode, so the one-shot resizes are replayed through the CLI.
+[[keys.command]]
+key = "prefix+ctrl+k"
+type = "shell"
+command = "\"$HERDR_BIN_PATH\" pane resize --pane \"$HERDR_ACTIVE_PANE_ID\" --direction up --amount 10"
+description = "resize pane up"
+
+[[keys.command]]
+key = "prefix+ctrl+j"
+type = "shell"
+command = "\"$HERDR_BIN_PATH\" pane resize --pane \"$HERDR_ACTIVE_PANE_ID\" --direction down --amount 10"
+description = "resize pane down"
+
+[[keys.command]]
+key = "prefix+ctrl+h"
+type = "shell"
+command = "\"$HERDR_BIN_PATH\" pane resize --pane \"$HERDR_ACTIVE_PANE_ID\" --direction left --amount 10"
+description = "resize pane left"
+
+[[keys.command]]
+key = "prefix+ctrl+l"
+type = "shell"
+command = "\"$HERDR_BIN_PATH\" pane resize --pane \"$HERDR_ACTIVE_PANE_ID\" --direction right --amount 10"
+description = "resize pane right"
+
+# tmux: `bind ^u swapp -U` / `bind ^d swapp -D`.
+[[keys.command]]
+key = "prefix+ctrl+u"
+type = "shell"
+command = "\"$HERDR_BIN_PATH\" pane swap --pane \"$HERDR_ACTIVE_PANE_ID\" --direction up"
+description = "swap pane up"
+
+[[keys.command]]
+key = "prefix+ctrl+d"
+type = "shell"
+command = "\"$HERDR_BIN_PATH\" pane swap --pane \"$HERDR_ACTIVE_PANE_ID\" --direction down"
+description = "swap pane down"
+
+# tmux: `bind ` splitw "gotop -c monokai"` — btop is the current equivalent.
+[[keys.command]]
+key = "prefix+backtick"
+type = "pane"
+command = "btop"
+description = "system monitor"
+
+# tmux: `bind m command-prompt "splitw 'exec man %%'"`.
+[[keys.command]]
+key = "prefix+m"
+type = "popup"
+command = "~/.config/herdr/scripts/herdr-man-popup.sh"
+width = "80%"
+height = "80%"
+description = "man page prompt"
+
+# tmux: `bind / command-prompt "splitw '%%'"`.
+[[keys.command]]
+key = "prefix+/"
+type = "popup"
+command = "~/.config/herdr/scripts/herdr-run-popup.sh"
+width = "80%"
+height = "80%"
+description = "run command prompt"
+
+# Scratch shell popup, matching tmux-floax's size. Replaced below by the
+# herdr-floax plugin, which keeps a persistent per-workspace session; this
+# stays as the zero-plugin fallback on prefix+shift+s.
+[[keys.command]]
+key = "prefix+shift+s"
+type = "popup"
+command = "exec \"${SHELL:-sh}\""
+width = "80%"
+height = "80%"
+description = "floating scratch shell (fallback)"
+
+[[keys.command]]
+key = "prefix+shift+l"
+type = "popup"
+command = "lazygit"
+width = "90%"
+height = "90%"
+description = "lazygit"
+
+# ================ Plugin actions ==================
+# Installed with `herdr plugin install` — see README.md. Keys mirror the tmux
+# bindings the plugins replace.
+
+# vim-tmux-navigator: direct ctrl+h/j/k/l, forwarded into nvim when it owns
+# the pane, otherwise moving Herdr's pane focus.
+[[keys.command]]
+key = "ctrl+h"
+type = "plugin_action"
+command = "vim-herdr-navigation.left"
+description = "navigate left (vim/herdr)"
+
+[[keys.command]]
+key = "ctrl+j"
+type = "plugin_action"
+command = "vim-herdr-navigation.down"
+description = "navigate down (vim/herdr)"
+
+[[keys.command]]
+key = "ctrl+k"
+type = "plugin_action"
+command = "vim-herdr-navigation.up"
+description = "navigate up (vim/herdr)"
+
+[[keys.command]]
+key = "ctrl+l"
+type = "plugin_action"
+command = "vim-herdr-navigation.right"
+description = "navigate right (vim/herdr)"
+
+# tmux-sessionx: `set -g @sessionx-bind 'o'`.
+[[keys.command]]
+key = "prefix+o"
+type = "plugin_action"
+command = "herdr-navigator.open"
+description = "workspace/session navigator"
+
+[[keys.command]]
+key = "prefix+shift+j"
+type = "plugin_action"
+command = "herdr-navigator.jump-back"
+description = "jump back to previous workspace"
+
+# tmux-floax: `set -g @floax-bind 'O'` at 80%x80%.
+[[keys.command]]
+key = "prefix+shift+o"
+type = "plugin_action"
+command = "herdr-floax.toggle"
+description = "toggle floating scratch pane"
+
+# tmux-which-key, which was bound to prefix+space.
+[[keys.command]]
+key = "prefix+space"
+type = "plugin_action"
+command = "jt.command-palette.open"
+description = "command palette"
+
+# tmux-thumbs: hint-based copying of visible tokens.
+[[keys.command]]
+key = "prefix+y"
+type = "plugin_action"
+command = "rmarganti.herdr-pluck.pluck"
+description = "pluck visible token (thumbs)"
+
+# tmux-fzf-url: `prefix+u` opens visible links; prefix+shift+u opens files.
+[[keys.command]]
+key = "prefix+u"
+type = "plugin_action"
+command = "termscope.open-links"
+description = "open visible link"
+
+[[keys.command]]
+key = "prefix+shift+u"
+type = "plugin_action"
+command = "termscope.open"
+description = "open visible file"
+
+# ================ Notifications ===================
+[ui.toast]
+delivery = "herdr"
+delay_seconds = 1
+
+[ui.toast.herdr]
+position = "bottom-right"
+
+[ui.toast.clipboard]
+enabled = true
+position = "bottom-center"
+
+[ui.sound]
+enabled = true
+
+# ================ Sidebar =========================
+# Herdr has no status bar and no tab-bar status region; the sidebar is the only
+# status surface. The tmux status-right modules (battery_hearts, outdated
+# packages, speedtest) are intentionally not ported -- see README.
+[ui.sidebar.spaces]
+row_gap = 0
+rows = [
+  ["state_icon", "workspace"],
+  ["branch", "git_status"],
+]
+
+[ui.sidebar.agents]
+row_gap = 0
+rows = [
+  ["state_icon", "workspace", "tab"],
+  ["agent"],
+]
+
+# ================ Session =========================
+[session]
+resume_agents_on_restore = true
+
+[advanced]
+scrollback_limit_bytes = 10000000

--- a/herdr/scripts/herdr-man-popup.sh
+++ b/herdr/scripts/herdr-man-popup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Herdr equivalent of tmux's `bind m command-prompt "splitw 'exec man %%'"`.
+#
+# Herdr has no command-prompt primitive, so the prompt lives inside the popup
+# that the keybinding opens. fzf is used for completion when available, exactly
+# like the rest of these dotfiles prefer it.
+set -uo pipefail
+
+page="${1:-}"
+
+if [ -z "$page" ]; then
+    if command -v fzf >/dev/null 2>&1; then
+        page=$(apropos . 2>/dev/null |
+            fzf --prompt='man > ' --height=100% --reverse --no-multi |
+            awk '{print $1}')
+    fi
+fi
+
+if [ -z "$page" ]; then
+    printf 'man: '
+    IFS= read -r page || exit 0
+fi
+
+[ -z "$page" ] && exit 0
+
+man "$page"

--- a/herdr/scripts/herdr-run-popup.sh
+++ b/herdr/scripts/herdr-run-popup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Herdr equivalent of tmux's `bind / command-prompt "splitw '%%'"`.
+#
+# Prompts for a command, runs it in the popup, then holds the popup open so the
+# output is readable — tmux kept the split around until the process exited.
+set -uo pipefail
+
+printf 'run: '
+IFS= read -r cmd || exit 0
+[ -z "$cmd" ] && exit 0
+
+"${SHELL:-/bin/sh}" -lc "$cmd"
+status=$?
+
+printf '\n[exit %s] press enter to close' "$status"
+IFS= read -r _ || true
+exit "$status"

--- a/install.sh
+++ b/install.sh
@@ -873,6 +873,18 @@ setup_herdr_plugins() {
     # Marketplace equivalents of the tmux plugins. herdr-floax and
     # herdr-navigator build with cargo; termscope needs python3.
     start_time=$(start_operation "Installing Herdr marketplace plugins")
+
+    # herdr-navigator <= v0.3.1 shipped with the plugin id `herdr-picker-plus`.
+    # The config binds `herdr-navigator.*`, so the stale id has to go or the
+    # rebuilt plugin cannot claim its actions.
+    if herdr plugin list 2>/dev/null | grep -q '^- herdr-picker-plus '; then
+        herdr plugin uninstall herdr-picker-plus >/dev/null 2>&1 ||
+            echo "⚠️  Failed to remove legacy Herdr plugin herdr-picker-plus" >> "$LOG_FILE"
+    fi
+
+    # `install` is also the update path in herdr 0.7 - there is no separate
+    # update command - so always re-run it rather than skipping on a source
+    # match, which would pin the first revision ever installed.
     local plugin
     for plugin in \
         paulbkim-dev/vim-herdr-navigation \
@@ -881,9 +893,6 @@ setup_herdr_plugins() {
         Tyru5/herdr-floax \
         thanhdat77/herdr-navigator \
         iurysza/termscope; do
-        if herdr plugin list 2>/dev/null | grep -q "github:$plugin@"; then
-            continue
-        fi
         herdr plugin install "$plugin" --yes >/dev/null 2>&1 ||
             echo "⚠️  Failed to install Herdr plugin $plugin" >> "$LOG_FILE"
     done

--- a/install.sh
+++ b/install.sh
@@ -865,7 +865,11 @@ function start_git_status_background() {
 # shellcheck disable=SC2031
 setup_herdr_plugins() {
     if ! command -v herdr >/dev/null 2>&1; then
+        # install_software does not provision herdr, so this is the normal path
+        # on a fresh Codespace. The plugins are a local-machine concern; see the
+        # herdr section of README.md for the manual steps.
         echo "⚠️  herdr not installed - skipping Herdr plugin setup" >> "$LOG_FILE"
+        echo "   (install herdr, then re-run ./install.sh or install the plugins manually)" >> "$LOG_FILE"
         return 0
     fi
 
@@ -885,6 +889,10 @@ setup_herdr_plugins() {
     # `install` is also the update path in herdr 0.7 - there is no separate
     # update command - so always re-run it rather than skipping on a source
     # match, which would pin the first revision ever installed.
+    # Build output goes to the log rather than /dev/null: the plugin installers
+    # report which prerequisite is missing (termscope, for instance, explains
+    # when Homebrew or Television is unavailable), and that is the only clue
+    # when a plugin fails to build.
     local plugin
     for plugin in \
         paulbkim-dev/vim-herdr-navigation \
@@ -893,8 +901,9 @@ setup_herdr_plugins() {
         Tyru5/herdr-floax \
         thanhdat77/herdr-navigator \
         iurysza/termscope; do
-        herdr plugin install "$plugin" --yes >/dev/null 2>&1 ||
-            echo "⚠️  Failed to install Herdr plugin $plugin" >> "$LOG_FILE"
+        if ! herdr plugin install "$plugin" --yes >> "$LOG_FILE" 2>&1; then
+            echo "⚠️  Failed to install Herdr plugin $plugin (see output above)" >> "$LOG_FILE"
+        fi
     done
     log_with_timing "Installing Herdr marketplace plugins" "$start_time"
 }

--- a/install.sh
+++ b/install.sh
@@ -193,6 +193,13 @@ function link_files() {
     ln -sf "$(pwd)/bottom" ~/.config/bottom
     ln -sf "$(pwd)/tmux" ~/.config/tmux
     ln -sf "$(pwd)/zellij" ~/.config/zellij
+
+    # Herdr keeps live sockets, logs and session state in ~/.config/herdr, and
+    # owns ~/.config/herdr/plugins for its own managed plugin checkouts, so the
+    # directory itself must not be replaced by a symlink. Link the pieces we own.
+    mkdir -p ~/.config/herdr
+    ln -sf "$(pwd)/herdr/config.toml" ~/.config/herdr/config.toml
+    ln -sfn "$(pwd)/herdr/scripts" ~/.config/herdr/scripts
     
     ln -sf "$(pwd)/delta" ~/.config/delta
     ln -sf "$(pwd)/eza" ~/.config/eza
@@ -852,6 +859,37 @@ function start_git_status_background() {
     echo $! > $git_pid_file
 }
 
+# Register the Herdr plugins that replace the tmux plugin set. They come from
+# the Herdr marketplace; `install` works with no server running and re-running
+# it is safe.
+# shellcheck disable=SC2031
+setup_herdr_plugins() {
+    if ! command -v herdr >/dev/null 2>&1; then
+        echo "⚠️  herdr not installed - skipping Herdr plugin setup" >> "$LOG_FILE"
+        return 0
+    fi
+
+    local start_time
+    # Marketplace equivalents of the tmux plugins. herdr-floax and
+    # herdr-navigator build with cargo; termscope needs python3.
+    start_time=$(start_operation "Installing Herdr marketplace plugins")
+    local plugin
+    for plugin in \
+        paulbkim-dev/vim-herdr-navigation \
+        JanTvrdik/herdr-command-palette \
+        rmarganti/herdr-pluck \
+        Tyru5/herdr-floax \
+        thanhdat77/herdr-navigator \
+        iurysza/termscope; do
+        if herdr plugin list 2>/dev/null | grep -q "github:$plugin@"; then
+            continue
+        fi
+        herdr plugin install "$plugin" --yes >/dev/null 2>&1 ||
+            echo "⚠️  Failed to install Herdr plugin $plugin" >> "$LOG_FILE"
+    done
+    log_with_timing "Installing Herdr marketplace plugins" "$start_time"
+}
+
 # shellcheck disable=SC2031
 echo '🔗 Starting file linking phase' >> "$LOG_FILE"
 link_files_start=$(date +%s)
@@ -869,6 +907,12 @@ echo '👩‍🔧 Starting software configuration phase' >> "$LOG_FILE"
 setup_software_start=$(date +%s)
 setup_software
 log_with_timing "👩‍🔧 Software configuration phase" "$setup_software_start"
+
+# shellcheck disable=SC2031
+echo '🐑 Starting Herdr plugin phase' >> "$LOG_FILE"
+herdr_plugins_start=$(date +%s)
+setup_herdr_plugins
+log_with_timing "🐑 Herdr plugin phase" "$herdr_plugins_start"
 
 # shellcheck disable=SC2031
 echo '✅ Installation completed successfully!' >> "$LOG_FILE"

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -57,7 +57,7 @@ The leader key is set to `,` (comma). Here are the main key mappings:
 ### Navigation
 - `<S-h>` / `<S-l>` - Previous/Next buffer
 - `<S-j>` / `<S-k>` - Next/Previous tab
-- `<C-h/j/k/l>` - Navigate splits (handled by vim-tmux-navigator)
+- `<C-h/j/k/l>` - Navigate splits (seamless across Neovim, Herdr and tmux panes)
 
 ### Finding & Search
 - `<leader>ff` - Find files (Telescope)
@@ -229,6 +229,11 @@ Search and replace across multiple files.
 
 #### [vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator)
 Seamless navigation between Neovim and tmux panes.
+
+`<C-h/j/k/l>` are bound once and work in either multiplexer. When Herdr's
+`vim-herdr-navigation` plugin is installed, its Neovim module is loaded and owns the
+mappings; otherwise they fall back to the `TmuxNavigate*` commands. See
+`nvim/lua/plugins/vim-tmux-navigator.lua`.
 
 ### Utilities
 

--- a/nvim/lua/plugins/vim-tmux-navigator.lua
+++ b/nvim/lua/plugins/vim-tmux-navigator.lua
@@ -1,10 +1,39 @@
+-- Seamless <C-h/j/k/l> movement between editor splits and the surrounding
+-- multiplexer.
+--
+-- vim-tmux-navigator still handles tmux, but its own mappings are disabled in
+-- favour of the vim-herdr-navigation editor module, which is a superset: it
+-- targets herdr when $HERDR_PANE_ID is set, falls back to tmux when $TMUX is
+-- set, and otherwise does a plain wincmd. One set of mappings, both
+-- multiplexers.
+--
+-- The herdr side of the plugin is installed with:
+--   herdr plugin install paulbkim-dev/vim-herdr-navigation
+local function herdr_nav_module()
+	local matches =
+		vim.fn.glob(vim.fn.expand("~/.config/herdr/plugins/github/vim-herdr-navigation-*/editor/nvim.lua"), true, true)
+	return matches[1]
+end
+
 return {
 	"christoomey/vim-tmux-navigator",
-	event = "VeryLazy",
-	keys = {
-		{ "<c-h>", ":TmuxNavigateLeft<CR>", desc = "Window Left" },
-		{ "<c-j>", ":TmuxNavigateDown<CR>", desc = "Window Down" },
-		{ "<c-k>", ":TmuxNavigateUp<CR>", desc = "Window Up" },
-		{ "<c-l>", ":TmuxNavigateRight<CR>", desc = "Window Right" },
-	},
+	lazy = false,
+	init = function()
+		vim.g.tmux_navigator_no_mappings = 1
+	end,
+	config = function()
+		local module = herdr_nav_module()
+		if module and vim.fn.filereadable(module) == 1 then
+			dofile(module)
+			return
+		end
+
+		-- herdr plugin not installed: fall back to vim-tmux-navigator's own
+		-- commands so tmux keeps working.
+		local map = vim.keymap.set
+		map("n", "<c-h>", "<cmd>TmuxNavigateLeft<cr>", { desc = "Window Left" })
+		map("n", "<c-j>", "<cmd>TmuxNavigateDown<cr>", { desc = "Window Down" })
+		map("n", "<c-k>", "<cmd>TmuxNavigateUp<cr>", { desc = "Window Up" })
+		map("n", "<c-l>", "<cmd>TmuxNavigateRight<cr>", { desc = "Window Right" })
+	end,
 }


### PR DESCRIPTION
Adds a [herdr](https://herdr.dev) config to the repo. Herdr is a terminal workspace manager for AI coding agents; this config is a deliberate mirror of `tmux/tmux.conf` so switching between the two costs no muscle memory — same `Ctrl+a` prefix, same Catppuccin palette, same bindings.

## What's here

- **`herdr/config.toml`** — full tmux parity. Pane focus/split/resize/swap, tab and workspace bindings, notifications, sidebar rows.
- **`herdr/scripts/`** — popup helpers replacing tmux's `command-prompt`, which herdr has no primitive for: `prefix m` (man pages, fzf-backed) and `prefix /` (arbitrary command).
- **`install.sh`** — links `config.toml` and `scripts/` individually and installs the marketplace plugins in a new phase.
- **`nvim`** — `<C-hjkl>` now routes through vim-herdr-navigation when present (it targets herdr or tmux depending on the environment), falling back to vim-tmux-navigator otherwise. One set of mappings, both multiplexers.

## tmux plugins → herdr

| tmux | herdr |
| --- | --- |
| vim-tmux-navigator | [vim-herdr-navigation](https://github.com/paulbkim-dev/vim-herdr-navigation) |
| tmux-sessionx | [herdr-navigator](https://github.com/thanhdat77/herdr-navigator) |
| tmux-floax | [herdr-floax](https://github.com/Tyru5/herdr-floax) |
| tmux-which-key | [herdr-command-palette](https://github.com/JanTvrdik/herdr-command-palette) |
| tmux-thumbs | [herdr-pluck](https://github.com/rmarganti/herdr-pluck) |
| tmux-fzf-url | [termscope](https://github.com/iurysza/termscope) |
| tmux-yank + `set-clipboard on` | `copy_on_select` |
| catppuccin/tmux | built-in `catppuccin` theme |

`tmux-pain-control`'s one-shot resizes and swaps are replayed through `[[keys.command]]` shelling out to `herdr pane resize` / `herdr pane swap`, since herdr only ships a modal resize mode.

## Intentionally not ported

Each was checked against herdr 0.7.5 and documented in the README:

- **`status-right` modules** (battery_hearts, outdated packages, speedtest) — herdr has no status bar, and its tab bar has no status region. The sidebar is the only surface that renders custom metadata tokens.
- **Contextual / nerd-font window naming** — herdr's native tab naming is used instead.
- **Rounded tab bubbles** — herdr has no tab separator config, sidebar token styles are foreground-only, and tab labels are padded inside the chip background, so the rounding can't be faked from a label.

## Notes

- Three herdr defaults were remapped to avoid collisions with the tmux bindings: `detach` → `prefix d`, `open_notification_target` → `prefix M`, freeing `prefix q` (kill pane) and `prefix o` (sessionx).
- GitHub Copilot CLI needs no setup — herdr detects it natively, which replaces the tmux config's Copilot window-title special-case. The optional `herdr integration install copilot` hook (session restore only) is documented but deliberately left out of `install.sh`.

## Validation

`herdr config check` passes and a live `server reload-config` applies with zero diagnostics. All bindings dispatch successfully. Locally verified against every CI linter: shellcheck, tomllint (exact CI globstar loop), stylua `--check`, and yamllint on tracked files. Both popup scripts are committed with mode `100755` and were executed to confirm they work.
