### PR TITLE
Add herdr agent and workspace navigation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Ripgrep is a line-oriented search tool that recursively searches directories for
 ### [rio](https://rioterm.com) ([repo](https://github.com/raphamorim/rio))
 Rio is a GPU-accelerated terminal emulator, configured here with the Catppuccin Mocha theme.
 - **Directory**: `rio/`
-- **Option key**: `option-as-alt = "left"` so `alt` chords (e.g. herdr's `prefix alt+1..9` agent focus) reach the app. Wezterm already does this by default; Ghostty defaults to it on U.S. layouts. Right Option still composes Unicode in all three.
+- **Option key**: `option-as-alt = "left"` so `alt` chords (e.g. herdr's `prefix alt+1..9` agent focus) reach the app. This matches wezterm's default, where left Option is Alt and right Option still composes Unicode. Ghostty needs no setting on U.S. layouts, but its default maps *both* Option keys to Alt — set `macos-option-as-alt = left` there if you want right Option to keep composing.
 
 ### [Starship](https://starship.rs) ([repo](https://github.com/starship/starship))
 Starship is a cross-shell prompt that displays information about the current directory, git status, and more.

--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ Herdr is a terminal workspace manager for AI coding agents. Its config is a deli
 | `prefix q` kill pane | same (detach moves to `prefix d`) | config |
 | `prefix p` / `n` previous/next window | same | config |
 | `prefix 1..9` select window | same | config |
+| `prefix (` / `)` previous/next session | `prefix ,` / `prefix .` previous/next workspace | config |
+| — | `prefix ^p` / `prefix ^n` previous/next agent | config |
+| — | `prefix alt+1..9` focus agent | config |
 | `prefix F1` / `^b` toggle status | `prefix b` / `prefix F1` toggle sidebar | config |
 | `prefix \`` gotop | `prefix \`` btop | `[[keys.command]]` |
 | `prefix m` man prompt | same | `herdr/scripts/herdr-man-popup.sh` |
@@ -319,6 +322,7 @@ Ripgrep is a line-oriented search tool that recursively searches directories for
 ### [rio](https://rioterm.com) ([repo](https://github.com/raphamorim/rio))
 Rio is a GPU-accelerated terminal emulator, configured here with the Catppuccin Mocha theme.
 - **Directory**: `rio/`
+- **Option key**: `option-as-alt = "left"` so `alt` chords (e.g. herdr's `prefix alt+1..9` agent focus) reach the app. Wezterm already does this by default; Ghostty defaults to it on U.S. layouts. Right Option still composes Unicode in all three.
 
 ### [Starship](https://starship.rs) ([repo](https://github.com/starship/starship))
 Starship is a cross-shell prompt that displays information about the current directory, git status, and more.

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -67,6 +67,17 @@ new_worktree = "prefix+shift+g"
 rename_workspace = "prefix+shift+w"
 close_workspace = "prefix+shift+d"
 switch_workspace = "prefix+shift+1..9"
+# tmux: `bind ( switch-client -p` / `bind ) switch-client -n`. Herdr's parser
+# takes named punctuation, so the shifted parens are spelled out.
+previous_workspace = "prefix+comma"
+next_workspace = "prefix+period"
+
+# --- Agents ---
+# tmux has no agent concept; these cycle the Agent sidebar rows and jump
+# straight to the pane running each agent.
+previous_agent = "prefix+ctrl+p"
+next_agent = "prefix+ctrl+n"
+focus_agent = "prefix+alt+1..9"
 
 # --- Tabs (tmux windows) ---
 new_tab = "prefix+c"

--- a/rio/config.toml
+++ b/rio/config.toml
@@ -11,6 +11,11 @@ scrollback-history-limit = 10000
 confirm-before-quit = false
 draw-bold-text-with-light-colors = false
 
+# macOS: Rio composes Unicode on Option by default, so alt chords (herdr's
+# `prefix+alt+1..9` agent focus) never reach the app. "left" matches wezterm's
+# default — left Option is Alt, right Option still composes (¡, £, €).
+option-as-alt = "left"
+
 # Outer window padding: [top, right, bottom, left]
 # Matches wezterm window_padding { top = 10, bottom = 10, left = 0, right = 0 }
 padding = [10, 0, 10, 0]


### PR DESCRIPTION
Binds the four Herdr navigation actions that ship unset by default, plus the one terminal-side setting needed to make them reachable on macOS.

## herdr/config.toml

| Binding | Action | Notes |
| --- | --- | --- |
| `prefix ,` / `prefix .` | `previous_workspace` / `next_workspace` | mirrors tmux `prefix (` / `prefix )` |
| `prefix ^p` / `prefix ^n` | `previous_agent` / `next_agent` | no tmux equivalent |
| `prefix alt+1..9` | `focus_agent` | Herdr's documented example binding |

All chords were free: `prefix p`/`n` stay on tabs, `prefix 1..9` on tabs, `prefix shift+1..9` on workspaces.

### Why not `ctrl+1..9` for `focus_agent`?

It parses fine, but legacy terminals cannot distinguish `ctrl+1` from `1` — it needs the kitty keyboard protocol (CSI-u). `wezterm/wezterm.lua:286-289` deliberately leaves that protocol off, because negotiating it mis-encodes arrow keys for TUI apps running inside tmux. A direct binding would also swallow nvim's built-in `<C-6>` before the pane sees it.

## rio/config.toml

Rio composes Unicode on Option by default (`alt+1` produces `¡`), so `prefix alt+1..9` never reached Herdr. `option-as-alt = "left"` matches WezTerm's default (left Option = Alt, right Option composes); Ghostty already defaults to this on U.S. layouts. Placed in the top-level block, before any section header, as Rio requires.

## Validation

- `herdr config check` → `config: ok` (it rejects unknown key names — confirmed by feeding it a bogus one)
- `herdr server reload-config` → applied live, no diagnostics
- Both TOML files parse; `yamllint .` shows only pre-existing failures in vendored `tmux/plugins/`
