### PR TITLE
Add install-pi, a one-command Raspberry Pi setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ wait $(cat ~/.dotfiles_neovim_setup.pid)  # Wait for Neovim setup
 
 **Performance:** The new parallel installation reduces foreground setup time by **93%** - from 5+ minutes down to ~20 seconds for immediate productivity!
 
+### Raspberry Pi Installation
+
+A Raspberry Pi (64-bit Raspberry Pi OS, `arm64`) gets the whole setup — apt
+packages, mise and every CLI tool, config symlinks, tmux/neovim/herdr plugins —
+from one command:
+
+```bash
+git clone https://github.com/djensenius/dotfiles.git ~/.dotfiles
+cd ~/.dotfiles
+./install-pi
+```
+
+It detects whether it needs `sudo`, escalates only for apt and `/etc/shells`,
+backs up any config it replaces, and is safe to re-run after a `git pull`.
+Add `--fish-shell` to make fish your login shell, or `--dry-run` to preview.
+
+See [pi/README.md](pi/README.md) for the full step list and options.
+
 ### Manual Local Installation
 
 For local installation, most configurations can be symlinked to your `~/.config` directory:

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ cd ~/.dotfiles
 ./install-pi
 ```
 
-It detects whether it needs `sudo`, escalates only for apt and `/etc/shells`,
-backs up any config it replaces, and is safe to re-run after a `git pull`.
+It detects whether it needs `sudo`, escalates only for apt, `/etc/shells` and
+`chsh`, backs up any config it replaces, and is safe to re-run after a
+`git pull`.
 Add `--fish-shell` to make fish your login shell, or `--dry-run` to preview.
 
 See [pi/README.md](pi/README.md) for the full step list and options.

--- a/install-pi
+++ b/install-pi
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Entry point: ./install-pi
+# Provisions a Raspberry Pi with these dotfiles. See pi/README.md.
+exec "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pi/install.sh" "$@"

--- a/pi/README.md
+++ b/pi/README.md
@@ -40,8 +40,9 @@ is the update path.
 | 7 | herdr plugins | The same marketplace plugins `install.sh` installs, including its removal of the legacy `herdr-picker-plus` id. |
 
 Progress goes to the terminal; full command output goes to `~/install-pi.log`
-(override with `INSTALL_PI_LOG`). `--dry-run` logs to a temporary file instead,
-so previewing never touches the real one.
+(override with `INSTALL_PI_LOG`). `--dry-run` writes no log at all — every line
+it would contain is already on the terminal — so previewing leaves nothing
+behind, including the real log.
 
 ## Options
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -24,20 +24,20 @@ is the update path.
   through `sudo`, it provisions `$SUDO_USER`'s account rather than root's.
 - Network access. mise downloads prebuilt binaries instead of building them,
   so the toolchain is minutes rather than the hours a source build would take.
-  The exception is step 5: `tmux-thumbs` and `tmux-floax` cargo-build on the
-  Pi.
+  The exceptions are the plugins: `tmux-thumbs` and `tmux-floax` (step 5) and
+  `herdr-floax` and `herdr-navigator` (step 7) cargo-build on the Pi.
 
 ## What it does
 
 | # | Step | Notes |
 | --- | --- | --- |
-| 1 | apt packages | `git`, `build-essential`, `python3`, `tmuxinator`, and friends. Falls back to installing one by one if a package is missing on your release. Generates a UTF-8 locale if the image has none. |
+| 1 | apt packages | `git`, `build-essential`, `python3`, `btop`, `tmuxinator`, and friends. Falls back to installing one by one if a package is missing on your release. Generates a UTF-8 locale if the image has none. |
 | 2 | mise | Installed from [its own apt repository](https://mise.jdx.dev), keyring and all. With `--skip-apt` it falls back to `https://mise.run`. |
-| 3 | Symlinks | Links this repo into `~/.config` (fish, nvim, tmux, starship, atuin, bat, bottom, btop, delta, eza, fastfetch, yazi, zellij, tmuxinator, gh, gh-dash, herdr) plus `~/.gitconfig` and friends. Anything already there is moved to `~/.dotfiles-backup/<timestamp>/` first. |
+| 3 | Symlinks | Links this repo into `~/.config` (fish, nvim, tmux, starship, atuin, bat, bottom, btop, delta, eza, fastfetch, yazi, zellij, tmuxinator, gh, gh-dash, herdr) plus `~/.gitconfig` and friends. Anything already there is moved to `~/.dotfiles-backup/<timestamp>/`, under its path relative to `~`, first. |
 | 4 | Tools | Copies [`mise.toml`](mise.toml) to `~/.config/mise/config.toml`, trusts it, and runs `mise install`. |
 | 5 | tmux plugins | Clones tpm and installs the plugin set. `tmux-thumbs` and `tmux-floax` build with cargo, which is why the manifest includes rust. |
 | 6 | Neovim | `nvim --headless "+Lazy! sync" +qa`. |
-| 7 | herdr plugins | The same marketplace plugins `install.sh` installs. |
+| 7 | herdr plugins | The same marketplace plugins `install.sh` installs, including its removal of the legacy `herdr-picker-plus` id. |
 
 Progress goes to the terminal; full command output goes to `~/install-pi.log`
 (override with `INSTALL_PI_LOG`). `--dry-run` logs to a temporary file instead,

--- a/pi/README.md
+++ b/pi/README.md
@@ -19,10 +19,13 @@ is the update path.
   only, so 32-bit `armhf` cannot reproduce the set. The script warns and keeps
   going if it detects another architecture.
 - A user with `sudo`, or run it as root. The script detects which it is and
-  only escalates for the steps that need it (apt, `/etc/shells`); everything
-  else runs as you, so nothing in `~` ends up owned by root.
-- Network access. Nothing is compiled — mise downloads prebuilt binaries — so
-  a full run is minutes rather than the hours a source build would take.
+  only escalates for the steps that need it (apt, `/etc/shells`, `chsh`);
+  everything else runs as you, so nothing in `~` ends up owned by root. Run
+  through `sudo`, it provisions `$SUDO_USER`'s account rather than root's.
+- Network access. mise downloads prebuilt binaries instead of building them,
+  so the toolchain is minutes rather than the hours a source build would take.
+  The exception is step 5: `tmux-thumbs` and `tmux-floax` cargo-build on the
+  Pi.
 
 ## What it does
 
@@ -37,7 +40,8 @@ is the update path.
 | 7 | herdr plugins | The same marketplace plugins `install.sh` installs. |
 
 Progress goes to the terminal; full command output goes to `~/install-pi.log`
-(override with `INSTALL_PI_LOG`).
+(override with `INSTALL_PI_LOG`). `--dry-run` logs to a temporary file instead,
+so previewing never touches the real one.
 
 ## Options
 
@@ -64,7 +68,8 @@ Not done by default, because a mise-managed fish lives under `~` rather than
 ./install-pi --fish-shell
 ```
 
-That appends the path to `/etc/shells` and runs `chsh`. **Open a second SSH
+That appends the path to `/etc/shells` and runs `chsh` as root against your
+account. **Open a second SSH
 session and confirm it works before closing the first** — a broken login shell
 also breaks `ssh host <command>`, which is awkward on a headless Pi. The path
 survives `mise upgrade`, because `latest` resolves through a symlink mise

--- a/pi/README.md
+++ b/pi/README.md
@@ -24,8 +24,10 @@ is the update path.
   through `sudo`, it provisions `$SUDO_USER`'s account rather than root's.
 - Network access. mise downloads prebuilt binaries instead of building them,
   so the toolchain is minutes rather than the hours a source build would take.
-  The exceptions are the plugins: `tmux-thumbs` and `tmux-floax` (step 5) and
-  `herdr-floax` and `herdr-navigator` (step 7) cargo-build on the Pi.
+  The exceptions are the plugins: `tmux-thumbs` and `tmux-floax` (step 5)
+  cargo-build, as do the herdr marketplace plugins in step 7 that publish no
+  arm64 binary — `herdr-floax`, `herdr-navigator` and `herdr-pluck` at the time
+  of writing.
 
 ## What it does
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -1,0 +1,93 @@
+# Raspberry Pi setup
+
+One command provisions a Raspberry Pi with these dotfiles and the whole
+command-line toolchain:
+
+```bash
+git clone https://github.com/djensenius/dotfiles.git ~/.dotfiles
+cd ~/.dotfiles
+./install-pi
+```
+
+It is safe to re-run — every step is idempotent, so `git pull && ./install-pi`
+is the update path.
+
+## Requirements
+
+- **64-bit Raspberry Pi OS (`arm64`)**, Lite or Desktop, on a Pi 4 or 5.
+  Several tools in [`mise.toml`](mise.toml) publish `aarch64` Linux binaries
+  only, so 32-bit `armhf` cannot reproduce the set. The script warns and keeps
+  going if it detects another architecture.
+- A user with `sudo`, or run it as root. The script detects which it is and
+  only escalates for the steps that need it (apt, `/etc/shells`); everything
+  else runs as you, so nothing in `~` ends up owned by root.
+- Network access. Nothing is compiled — mise downloads prebuilt binaries — so
+  a full run is minutes rather than the hours a source build would take.
+
+## What it does
+
+| # | Step | Notes |
+| --- | --- | --- |
+| 1 | apt packages | `git`, `build-essential`, `python3`, `tmuxinator`, and friends. Falls back to installing one by one if a package is missing on your release. Generates a UTF-8 locale if the image has none. |
+| 2 | mise | Installed from [its own apt repository](https://mise.jdx.dev), keyring and all. With `--skip-apt` it falls back to `https://mise.run`. |
+| 3 | Symlinks | Links this repo into `~/.config` (fish, nvim, tmux, starship, atuin, bat, bottom, btop, delta, eza, fastfetch, yazi, zellij, tmuxinator, gh, gh-dash, herdr) plus `~/.gitconfig` and friends. Anything already there is moved to `~/.dotfiles-backup/<timestamp>/` first. |
+| 4 | Tools | Copies [`mise.toml`](mise.toml) to `~/.config/mise/config.toml`, trusts it, and runs `mise install`. |
+| 5 | tmux plugins | Clones tpm and installs the plugin set. `tmux-thumbs` and `tmux-floax` build with cargo, which is why the manifest includes rust. |
+| 6 | Neovim | `nvim --headless "+Lazy! sync" +qa`. |
+| 7 | herdr plugins | The same marketplace plugins `install.sh` installs. |
+
+Progress goes to the terminal; full command output goes to `~/install-pi.log`
+(override with `INSTALL_PI_LOG`).
+
+## Options
+
+```text
+--skip-apt      No package installs, and mise comes from mise.run instead
+--skip-mise     Leave mise and ~/.config/mise/config.toml alone
+--skip-links    No ~/.config symlinks
+--skip-tmux     No tmux plugins
+--skip-nvim     No neovim plugin sync
+--skip-herdr    No herdr plugins
+--fish-shell    Make the mise-managed fish the login shell (chsh)
+--force         Overwrite existing configs instead of backing them up
+--dry-run       Print every action without doing it
+--yes, -y       No confirmation prompt
+--help, -h      Usage
+```
+
+## Making fish the login shell
+
+Not done by default, because a mise-managed fish lives under `~` rather than
+`/usr/bin`:
+
+```bash
+./install-pi --fish-shell
+```
+
+That appends the path to `/etc/shells` and runs `chsh`. **Open a second SSH
+session and confirm it works before closing the first** — a broken login shell
+also breaks `ssh host <command>`, which is awkward on a headless Pi. The path
+survives `mise upgrade`, because `latest` resolves through a symlink mise
+repoints at each release. If you would rather not couple your login shell to
+mise, `sudo apt install fish` gives you an older fish at `/usr/bin/fish`.
+
+## Afterwards
+
+- Open a new shell so mise's shims are on `PATH`.
+- `atuin login -u <user>` once, to sync shell history.
+- `gh auth login`, if you want the GitHub CLI and gh-dash.
+
+## Relationship to install.sh
+
+[`install.sh`](../install.sh) provisions GitHub Codespaces: it assumes a
+throwaway container, installs via cargo/npm/gem, and parallelises aggressively.
+`install-pi` targets a long-lived machine you SSH into: it prefers mise
+binaries over compiling on a Pi's CPU, backs up rather than deletes what it
+finds, and can be re-run to update.
+
+[`mise.toml`](mise.toml) here is the Pi tool manifest and is unrelated to
+[`../mise/config.toml`](../mise/config.toml), which is the workstation set
+(go, ruby, python, kubectl, npm packages) and would be a long, largely
+source-built install on a Pi. It started as Telephone-Booth's
+`packaging/raspberry-pi/mise.toml`, with the extra tools these dotfiles assume
+(zoxide, fzf, ripgrep, fd, node, rust).

--- a/pi/install.sh
+++ b/pi/install.sh
@@ -9,8 +9,12 @@ set -euo pipefail
 
 PI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOTFILES_DIR="$(cd "$PI_DIR/.." && pwd)"
-LOG_FILE="${INSTALL_PI_LOG:-$HOME/install-pi.log}"
-BACKUP_DIR="$HOME/.dotfiles-backup/$(date +%Y%m%d-%H%M%S)"
+# Filled in by detect_target_user and init_logging, once HOME is known to
+# point at the account being provisioned rather than root's.
+TARGET_USER=""
+DEMOTE_USER=""
+LOG_FILE=""
+BACKUP_DIR=""
 
 DO_APT=true
 DO_MISE=true
@@ -55,14 +59,30 @@ else
     C_BOLD=''; C_DIM=''; C_RED=''; C_GREEN=''; C_YELLOW=''; C_RESET=''
 fi
 
-log()  { printf '%s\n' "$*"; printf '[%s] %s\n' "$(date '+%F %T')" "$*" >>"$LOG_FILE"; }
-step() { printf '\n%s==> %s%s\n' "$C_BOLD" "$*" "$C_RESET"; printf '\n[%s] ==> %s\n' "$(date '+%F %T')" "$*" >>"$LOG_FILE"; }
+log_to_file() {
+    [ -n "$LOG_FILE" ] || return 0
+    printf '[%s] %s\n' "$(date '+%F %T')" "$*" >>"$LOG_FILE"
+}
+
+log()  { printf '%s\n' "$*"; log_to_file "$*"; }
+step() { printf '\n%s==> %s%s\n' "$C_BOLD" "$*" "$C_RESET"; log_to_file "==> $*"; }
 ok()   { log "${C_GREEN}✓${C_RESET} $*"; }
 skip() { log "${C_DIM}·${C_RESET} $*"; }
 warn() { log "${C_YELLOW}⚠${C_RESET} $*"; }
 die()  { log "${C_RED}✗${C_RESET} $*"; exit 1; }
 
 have() { command -v "$1" >/dev/null 2>&1; }
+
+# A dry run must leave the disk untouched, including whatever INSTALL_PI_LOG
+# points at, which a real run truncates. So it logs to a throwaway file.
+init_logging() {
+    if $DRY_RUN; then
+        LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/install-pi-dry-run.XXXXXX")"
+        return 0
+    fi
+    LOG_FILE="${INSTALL_PI_LOG:-$HOME/install-pi.log}"
+    run_as_user install -m 644 /dev/null "$LOG_FILE" 2>/dev/null || : >"$LOG_FILE"
+}
 
 show_help() {
     cat <<'EOF'
@@ -93,7 +113,8 @@ Options:
   --help, -h        Show this help
 
 Environment:
-  INSTALL_PI_LOG    Log file path (default: ~/install-pi.log)
+  INSTALL_PI_LOG    Log file path (default: ~/install-pi.log). --dry-run logs
+                    to a temporary file and leaves this one alone.
 
 Everything is idempotent — re-run it after `git pull` to pick up changes.
 EOF
@@ -102,6 +123,34 @@ EOF
 # ------------------------------------------------------------ privileges ----
 
 SUDO=""
+
+# Work out whose machine this actually is. Under `sudo ./install-pi` the
+# process is root but the account being provisioned is $SUDO_USER, so HOME is
+# repointed and every non-privileged command is demoted back to that user —
+# otherwise the symlinks, plugin checkouts and chsh would all land on root.
+detect_target_user() {
+    if [ "$(id -u)" -ne 0 ]; then
+        TARGET_USER="$(id -un)"
+        DEMOTE_USER=""
+        return 0
+    fi
+
+    if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+        TARGET_USER="$SUDO_USER"
+        DEMOTE_USER="$SUDO_USER"
+    else
+        TARGET_USER="root"
+        DEMOTE_USER=""
+    fi
+
+    local home
+    home="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
+    [ -n "$home" ] ||
+        printf 'Cannot resolve the home directory of %s\n' "$TARGET_USER" >&2
+    [ -n "$home" ] || exit 1
+    export HOME="$home"
+    export USER="$TARGET_USER" LOGNAME="$TARGET_USER"
+}
 
 setup_sudo() {
     if [ "$(id -u)" -eq 0 ]; then
@@ -137,13 +186,23 @@ apt_get() {
     as_root env DEBIAN_FRONTEND=noninteractive apt-get "$@"
 }
 
-# Run a command as the current user.
+# Run a command as the account being provisioned. PATH is passed through
+# explicitly because sudo resets it, and later phases rely on the mise shims
+# this script prepends.
+run_as_user() {
+    if [ -n "$DEMOTE_USER" ]; then
+        sudo -u "$DEMOTE_USER" -H env "PATH=$PATH" "$@"
+    else
+        "$@"
+    fi
+}
+
 as_user() {
     if $DRY_RUN; then
         log "${C_DIM}[dry-run] $*${C_RESET}"
         return 0
     fi
-    "$@"
+    run_as_user "$@"
 }
 
 # ---------------------------------------------------------------- checks ----
@@ -173,6 +232,7 @@ preflight() {
     [ -d "$DOTFILES_DIR/fish" ] ||
         die "$DOTFILES_DIR does not look like the dotfiles repo (no fish/ directory)."
     ok "Dotfiles: $DOTFILES_DIR"
+    ok "Provisioning: $TARGET_USER (home: $HOME)"
     ok "Log: $LOG_FILE"
 
     if ! $ASSUME_YES && ! $DRY_RUN && [ -t 0 ]; then
@@ -421,9 +481,11 @@ install_tmux_plugins() {
 
     # tmux-thumbs and tmux-floax build with cargo, so this needs the mise rust.
     log "Installing tmux plugins (a couple of these build from source)"
-    as_user "$tpm/bin/install_plugins" >>"$LOG_FILE" 2>&1 ||
+    if as_user "$tpm/bin/install_plugins" >>"$LOG_FILE" 2>&1; then
+        ok "tmux plugins installed"
+    else
         warn "Some tmux plugins failed to install — see $LOG_FILE"
-    ok "tmux plugins installed"
+    fi
 }
 
 sync_neovim() {
@@ -436,9 +498,11 @@ sync_neovim() {
     fi
 
     log "Running lazy.nvim sync headless (a few minutes on a first run)"
-    as_user nvim --headless "+Lazy! sync" +qa >>"$LOG_FILE" 2>&1 ||
+    if as_user nvim --headless "+Lazy! sync" +qa >>"$LOG_FILE" 2>&1; then
+        ok "Neovim plugins synced"
+    else
         warn "Neovim plugin sync reported errors — see $LOG_FILE"
-    ok "Neovim plugins synced"
+    fi
 }
 
 install_herdr_plugins() {
@@ -450,7 +514,7 @@ install_herdr_plugins() {
         return
     fi
 
-    local plugin
+    local plugin failed=()
     for plugin in \
         paulbkim-dev/vim-herdr-navigation \
         JanTvrdik/herdr-command-palette \
@@ -459,9 +523,13 @@ install_herdr_plugins() {
         thanhdat77/herdr-navigator \
         iurysza/termscope; do
         as_user herdr plugin install "$plugin" --yes >>"$LOG_FILE" 2>&1 ||
-            warn "Failed to install herdr plugin $plugin — see $LOG_FILE"
+            failed+=("$plugin")
     done
-    ok "herdr plugins installed"
+    if [ ${#failed[@]} -gt 0 ]; then
+        warn "Failed to install herdr plugins: ${failed[*]} — see $LOG_FILE"
+    else
+        ok "herdr plugins installed"
+    fi
 }
 
 # ------------------------------------------------------------ login shell ----
@@ -474,26 +542,37 @@ set_login_shell() {
     if $DRY_RUN; then
         fish_path="$HOME/.local/share/mise/installs/fish/latest/bin/fish"
     else
-        fish_path="$(mise which fish 2>/dev/null || command -v fish || true)"
+        fish_path="$(run_as_user mise which fish 2>/dev/null || true)"
+        [ -n "$fish_path" ] || fish_path="$(command -v fish || true)"
         if [ -z "$fish_path" ]; then
             warn "fish not found; not changing the login shell"
             return 0
         fi
     fi
 
-    if [ "${SHELL:-}" = "$fish_path" ]; then
-        skip "fish is already the login shell"
+    local current_shell
+    current_shell="$(getent passwd "$TARGET_USER" | cut -d: -f7)"
+    if [ "$current_shell" = "$fish_path" ]; then
+        skip "fish is already $TARGET_USER's login shell"
         return
     fi
 
     if ! grep -qxF "$fish_path" /etc/shells 2>/dev/null; then
-        printf '%s\n' "$fish_path" | as_root tee -a /etc/shells >/dev/null
+        if $DRY_RUN; then
+            log "${C_DIM}[dry-run] append $fish_path to /etc/shells${C_RESET}"
+        else
+            printf '%s\n' "$fish_path" | as_root tee -a /etc/shells >/dev/null
+        fi
     fi
-    as_user chsh -s "$fish_path" ||
-        warn "chsh failed; run: chsh -s $fish_path"
 
-    warn "Your login shell now depends on mise. Open a second SSH session and confirm it works before closing this one."
-    ok "Login shell set to $fish_path"
+    # chsh runs as root and names the account explicitly: as the user it would
+    # prompt for a password, and under sudo it would retarget root's shell.
+    if as_root chsh -s "$fish_path" "$TARGET_USER"; then
+        warn "Your login shell now depends on mise. Open a second SSH session and confirm it works before closing this one."
+        ok "Login shell for $TARGET_USER set to $fish_path"
+    else
+        warn "chsh failed; run: chsh -s $fish_path $TARGET_USER"
+    fi
 }
 
 # ----------------------------------------------------------------- main ------
@@ -517,7 +596,10 @@ main() {
         shift
     done
 
-    : >"$LOG_FILE"
+    detect_target_user
+    init_logging
+    BACKUP_DIR="$HOME/.dotfiles-backup/$(date +%Y%m%d-%H%M%S)"
+
     local start_time
     start_time=$(date +%s)
 

--- a/pi/install.sh
+++ b/pi/install.sh
@@ -389,14 +389,7 @@ install_mise_tools() {
     # On a workstation ~/.config/mise is a symlink to this repo's mise/ (see
     # fish/config.fish). Writing config.toml through it would rewrite the repo's
     # own workstation manifest, so the link is replaced by a real directory.
-    if [ -L "$mise_dir" ]; then
-        if $FORCE; then
-            as_user rm -f "$mise_dir"
-        else
-            backup_path "$mise_dir"
-        fi
-    fi
-    as_user mkdir -p "$mise_dir"
+    ensure_real_dir "$mise_dir"
 
     # A copy, not a symlink: mise treats a config resolved through a symlink
     # into the repo as non-global. That also means an existing symlink has to
@@ -439,6 +432,22 @@ backup_path() {
     as_user mkdir -p "$(dirname "$dest")"
     as_user mv "$target" "$dest"
     warn "Backed up ${target/#$HOME/\~} to ${dest/#$HOME/\~}"
+}
+
+# Make sure <path> is a real directory. A symlink there — the workstation
+# layout links ~/.config/mise into this repo, and ~/.config/herdr could be
+# linked the same way — would send everything written "inside" it into the
+# clone instead.
+ensure_real_dir() {
+    local dir="$1"
+    if [ -L "$dir" ]; then
+        if $FORCE; then
+            as_user rm -f "$dir"
+        else
+            backup_path "$dir"
+        fi
+    fi
+    as_user mkdir -p "$dir"
 }
 
 # link_config <repo-relative source> <absolute target>
@@ -504,7 +513,7 @@ link_configs() {
     # herdr keeps live sockets, logs and its own plugin checkouts in
     # ~/.config/herdr, so the directory itself must stay real — link only the
     # pieces this repo owns.
-    as_user mkdir -p "$HOME/.config/herdr"
+    ensure_real_dir "$HOME/.config/herdr"
     link_config herdr/config.toml "$HOME/.config/herdr/config.toml"
     link_config herdr/scripts "$HOME/.config/herdr/scripts"
 

--- a/pi/install.sh
+++ b/pi/install.sh
@@ -81,7 +81,14 @@ init_logging() {
         return 0
     fi
     LOG_FILE="${INSTALL_PI_LOG:-$HOME/install-pi.log}"
-    run_as_user install -m 644 /dev/null "$LOG_FILE" 2>/dev/null || : >"$LOG_FILE"
+    local dir
+    dir="$(dirname "$LOG_FILE")"
+    run_as_user mkdir -p "$dir" 2>/dev/null || mkdir -p "$dir" 2>/dev/null || true
+    # install(1) so the file belongs to the target user, not root, when this
+    # was started with sudo.
+    run_as_user install -m 644 /dev/null "$LOG_FILE" 2>/dev/null ||
+        : >"$LOG_FILE" ||
+        { printf 'Cannot write to log file %s\n' "$LOG_FILE" >&2; exit 1; }
 }
 
 show_help() {

--- a/pi/install.sh
+++ b/pi/install.sh
@@ -1,0 +1,559 @@
+#!/usr/bin/env bash
+# Raspberry Pi provisioning: apt packages, mise + tools, dotfiles symlinks,
+# tmux/neovim/herdr plugins. Run it with ../install-pi from a clone of this
+# repo.
+#
+# Safe to re-run: every step is idempotent and skips work already done.
+
+set -euo pipefail
+
+PI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOTFILES_DIR="$(cd "$PI_DIR/.." && pwd)"
+LOG_FILE="${INSTALL_PI_LOG:-$HOME/install-pi.log}"
+BACKUP_DIR="$HOME/.dotfiles-backup/$(date +%Y%m%d-%H%M%S)"
+
+DO_APT=true
+DO_MISE=true
+DO_LINKS=true
+DO_TMUX=true
+DO_NVIM=true
+DO_HERDR=true
+SET_FISH_SHELL=false
+DRY_RUN=false
+ASSUME_YES=false
+FORCE=false
+
+APT_PACKAGES=(
+    ca-certificates
+    curl
+    wget
+    gpg
+    git
+    git-lfs
+    unzip
+    zip
+    xz-utils
+    tar
+    rsync
+    less
+    locales
+    build-essential
+    pkg-config
+    libssl-dev
+    python3
+    python3-pip
+    python3-venv
+    tmuxinator
+)
+
+# ---------------------------------------------------------------- output ----
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    C_BOLD=$'\033[1m'; C_DIM=$'\033[2m'; C_RED=$'\033[31m'
+    C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'; C_RESET=$'\033[0m'
+else
+    C_BOLD=''; C_DIM=''; C_RED=''; C_GREEN=''; C_YELLOW=''; C_RESET=''
+fi
+
+log()  { printf '%s\n' "$*"; printf '[%s] %s\n' "$(date '+%F %T')" "$*" >>"$LOG_FILE"; }
+step() { printf '\n%s==> %s%s\n' "$C_BOLD" "$*" "$C_RESET"; printf '\n[%s] ==> %s\n' "$(date '+%F %T')" "$*" >>"$LOG_FILE"; }
+ok()   { log "${C_GREEN}✓${C_RESET} $*"; }
+skip() { log "${C_DIM}·${C_RESET} $*"; }
+warn() { log "${C_YELLOW}⚠${C_RESET} $*"; }
+die()  { log "${C_RED}✗${C_RESET} $*"; exit 1; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+show_help() {
+    cat <<'EOF'
+install-pi — provision a Raspberry Pi with these dotfiles and tools
+
+Usage: ./install-pi [OPTIONS]
+
+Runs, in order:
+  1. apt packages (git, build tools, python, ...)
+  2. mise, from its own apt repository
+  3. dotfiles symlinks into ~/.config
+  4. pi/mise.toml -> ~/.config/mise/config.toml, then `mise install`
+  5. tmux plugin manager + plugins
+  6. neovim plugin sync (headless)
+  7. herdr marketplace plugins
+
+Options:
+  --skip-apt        Do not touch apt (no package installs, no mise repo)
+  --skip-mise       Do not install mise or its tool manifest
+  --skip-links      Do not create ~/.config symlinks
+  --skip-tmux       Do not install tmux plugins
+  --skip-nvim       Do not sync neovim plugins
+  --skip-herdr      Do not install herdr plugins
+  --fish-shell      Make the mise-managed fish your login shell (chsh)
+  --force           Replace existing config files instead of backing them up
+  --dry-run         Print what would run without changing anything
+  --yes, -y         Do not prompt for confirmation
+  --help, -h        Show this help
+
+Environment:
+  INSTALL_PI_LOG    Log file path (default: ~/install-pi.log)
+
+Everything is idempotent — re-run it after `git pull` to pick up changes.
+EOF
+}
+
+# ------------------------------------------------------------ privileges ----
+
+SUDO=""
+
+setup_sudo() {
+    if [ "$(id -u)" -eq 0 ]; then
+        SUDO=""
+        skip "Running as root; sudo not needed"
+        return
+    fi
+    have sudo || die "Not root and sudo is not installed. Re-run as root, or install sudo."
+    SUDO="sudo"
+    if sudo -n true 2>/dev/null; then
+        ok "sudo available without a password prompt"
+    else
+        log "sudo needs your password for the apt steps."
+        $DRY_RUN || sudo -v || die "Could not obtain sudo privileges"
+    fi
+}
+
+# Run a command as root (or directly, when already root).
+as_root() {
+    if $DRY_RUN; then
+        log "${C_DIM}[dry-run] ${SUDO:+sudo }$*${C_RESET}"
+        return 0
+    fi
+    if [ -n "$SUDO" ]; then
+        sudo "$@"
+    else
+        "$@"
+    fi
+}
+
+# apt-get as root, never prompting for interactive config.
+apt_get() {
+    as_root env DEBIAN_FRONTEND=noninteractive apt-get "$@"
+}
+
+# Run a command as the current user.
+as_user() {
+    if $DRY_RUN; then
+        log "${C_DIM}[dry-run] $*${C_RESET}"
+        return 0
+    fi
+    "$@"
+}
+
+# ---------------------------------------------------------------- checks ----
+
+preflight() {
+    step "Preflight"
+
+    [ "$(uname -s)" = "Linux" ] ||
+        die "install-pi targets Raspberry Pi OS / Debian. On macOS use the README's manual steps."
+
+    if $DO_APT; then
+        have apt-get || die "apt-get not found — this script only supports Debian-based systems."
+    fi
+
+    local arch
+    arch="$(uname -m)"
+    case "$arch" in
+        aarch64|arm64) ok "Architecture: $arch" ;;
+        *) warn "Architecture is $arch, not aarch64. Several tools in pi/mise.toml publish aarch64 binaries only and will fail to install." ;;
+    esac
+
+    if [ -r /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        ok "OS: $(. /etc/os-release && echo "$PRETTY_NAME")"
+    fi
+
+    [ -d "$DOTFILES_DIR/fish" ] ||
+        die "$DOTFILES_DIR does not look like the dotfiles repo (no fish/ directory)."
+    ok "Dotfiles: $DOTFILES_DIR"
+    ok "Log: $LOG_FILE"
+
+    if ! $ASSUME_YES && ! $DRY_RUN && [ -t 0 ]; then
+        printf '\nProceed? [Y/n] '
+        local reply
+        read -r reply
+        case "$reply" in
+            [nN]*) die "Aborted." ;;
+        esac
+    fi
+}
+
+# ------------------------------------------------------------------ apt ------
+
+install_apt_packages() {
+    $DO_APT || { skip "Skipping apt packages (--skip-apt)"; return; }
+    step "Installing apt packages"
+
+    apt_get update
+
+    # One batch is much faster, but a single unavailable package (tmuxinator is
+    # not in every Debian release) would abort the lot — so fall back to
+    # installing individually and only warn about what is genuinely missing.
+    if apt_get install -y --no-install-recommends "${APT_PACKAGES[@]}"; then
+        ok "Installed ${#APT_PACKAGES[@]} apt packages"
+    else
+        warn "Batch install failed; retrying package by package"
+        local pkg failed=()
+        for pkg in "${APT_PACKAGES[@]}"; do
+            apt_get install -y --no-install-recommends "$pkg" >>"$LOG_FILE" 2>&1 ||
+                failed+=("$pkg")
+        done
+        if [ ${#failed[@]} -gt 0 ]; then
+            warn "Unavailable on this release: ${failed[*]}"
+        fi
+        ok "Installed remaining apt packages"
+    fi
+
+    ensure_locale
+}
+
+ensure_locale() {
+    # fish, neovim and the Catppuccin/nerd-font glyphs all assume a UTF-8
+    # locale; Raspberry Pi OS Lite ships without one generated.
+    if locale -a 2>/dev/null | grep -qiE '^(en_US\.utf-?8|C\.utf-?8)$'; then
+        skip "UTF-8 locale already available"
+        return
+    fi
+    log "Generating en_US.UTF-8 locale"
+    as_root sed -i 's/^# *en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+    as_root locale-gen
+    as_root update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+    ok "Locale set to en_US.UTF-8"
+}
+
+# ----------------------------------------------------------------- mise ------
+
+install_mise() {
+    $DO_MISE || { skip "Skipping mise (--skip-mise)"; return; }
+    step "Installing mise"
+
+    if have mise; then
+        ok "mise already installed ($(mise --version 2>/dev/null | head -1))"
+        return
+    fi
+
+    if ! $DO_APT; then
+        # --skip-apt rules out mise's apt repository, so use its own installer.
+        log "Installing mise via https://mise.run (apt steps skipped)"
+        as_user bash -c 'curl -fsSL https://mise.run | sh'
+        export PATH="$HOME/.local/bin:$PATH"
+        if ! have mise && ! $DRY_RUN; then
+            die "mise install failed"
+        fi
+        ok "mise installed to ~/.local/bin/mise"
+        return
+    fi
+
+    as_root install -dm 755 /etc/apt/keyrings
+    if [ ! -s /etc/apt/keyrings/mise-archive-keyring.gpg ]; then
+        if $DRY_RUN; then
+            log "${C_DIM}[dry-run] fetch mise gpg key -> /etc/apt/keyrings/mise-archive-keyring.gpg${C_RESET}"
+        else
+            wget -qO - https://mise.jdx.dev/gpg-key.pub |
+                gpg --dearmor |
+                as_root tee /etc/apt/keyrings/mise-archive-keyring.gpg >/dev/null
+        fi
+    fi
+
+    local arch line
+    arch="$(dpkg --print-architecture 2>/dev/null || echo arm64)"
+    line="deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=$arch] https://mise.jdx.dev/deb stable main"
+    if $DRY_RUN; then
+        log "${C_DIM}[dry-run] write /etc/apt/sources.list.d/mise.list${C_RESET}"
+    else
+        printf '%s\n' "$line" | as_root tee /etc/apt/sources.list.d/mise.list >/dev/null
+    fi
+
+    apt_get update
+    apt_get install -y mise
+    ok "mise installed from its apt repository"
+}
+
+install_mise_tools() {
+    $DO_MISE || { skip "Skipping mise tools (--skip-mise)"; return; }
+    step "Installing tools with mise"
+
+    if ! have mise && ! $DRY_RUN; then
+        warn "mise not on PATH; skipping tool install"
+        return 0
+    fi
+
+    as_user mkdir -p "$HOME/.config/mise"
+    local mise_config="$HOME/.config/mise/config.toml"
+    # A copy, not a symlink: mise treats a config resolved through a symlink
+    # into the repo as non-global. That also means an existing symlink has to
+    # go first, or cp would follow it and overwrite the file it points at
+    # (mise/config.toml in this repo, for anyone who linked the workstation
+    # manifest there).
+    if [ -e "$mise_config" ] || [ -L "$mise_config" ]; then
+        if ! $FORCE && ! cmp -s "$PI_DIR/mise.toml" "$mise_config" 2>/dev/null; then
+            as_user mkdir -p "$BACKUP_DIR"
+            as_user cp -P "$mise_config" "$BACKUP_DIR/mise-config.toml"
+            warn "Backed up existing ~/.config/mise/config.toml to ${BACKUP_DIR/#$HOME/\~}"
+        fi
+        as_user rm -f "$mise_config"
+    fi
+    as_user cp "$PI_DIR/mise.toml" "$mise_config"
+    ok "Wrote ~/.config/mise/config.toml from pi/mise.toml"
+
+    as_user mise trust "$mise_config"
+    log "Running mise install (downloads prebuilt binaries; a few minutes on a Pi)"
+    as_user mise install
+    ok "mise tools installed"
+
+    # Later phases (tmux plugins, nvim sync, herdr) need the freshly installed
+    # binaries in this shell's PATH.
+    local shims="$HOME/.local/share/mise/shims"
+    if [ -d "$shims" ]; then
+        export PATH="$shims:$PATH"
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------- links ------
+
+# link_config <repo-relative source> <absolute target>
+link_config() {
+    local src="$DOTFILES_DIR/$1" target="$2"
+
+    if [ ! -e "$src" ]; then
+        warn "Missing in repo, not linked: $1"
+        return
+    fi
+
+    if [ -L "$target" ] && [ "$(readlink "$target")" = "$src" ]; then
+        skip "Already linked: ${target/#$HOME/\~}"
+        return
+    fi
+
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        if $FORCE; then
+            as_user rm -rf "$target"
+        else
+            as_user mkdir -p "$BACKUP_DIR"
+            as_user mv "$target" "$BACKUP_DIR/$(basename "$target")"
+            warn "Backed up existing ${target/#$HOME/\~} to ${BACKUP_DIR/#$HOME/\~}"
+        fi
+    fi
+
+    as_user mkdir -p "$(dirname "$target")"
+    # -n so a re-run replaces a symlink rather than dereferencing it and
+    # creating a nested copy inside the target directory.
+    as_user ln -sfn "$src" "$target"
+    ok "Linked ${target/#$HOME/\~} -> $1"
+}
+
+link_configs() {
+    $DO_LINKS || { skip "Skipping symlinks (--skip-links)"; return; }
+    step "Linking config files"
+
+    as_user mkdir -p "$HOME/.config" "$HOME/.local/bin"
+
+    link_config gitconfig "$HOME/.gitconfig"
+    link_config gitignore_local "$HOME/.gitignore_local"
+    link_config vale.ini "$HOME/.vale.ini"
+
+    link_config fish "$HOME/.config/fish"
+    link_config nvim "$HOME/.config/nvim"
+    link_config tmux "$HOME/.config/tmux"
+    link_config starship.toml "$HOME/.config/starship.toml"
+
+    link_config atuin "$HOME/.config/atuin"
+    link_config bat "$HOME/.config/bat"
+    link_config bottom "$HOME/.config/bottom"
+    link_config btop "$HOME/.config/btop"
+    link_config delta "$HOME/.config/delta"
+    link_config eza "$HOME/.config/eza"
+    link_config fastfetch "$HOME/.config/fastfetch"
+    link_config yazi "$HOME/.config/yazi"
+    link_config zellij "$HOME/.config/zellij"
+    link_config tmuxinator "$HOME/.config/tmuxinator"
+    link_config gitmux.conf "$HOME/.config/gitmux.conf"
+    link_config prettierrc.json "$HOME/.config/prettierrc.json"
+
+    link_config gh/config.yml "$HOME/.config/gh/config.yml"
+    link_config gh-dash/config.yml "$HOME/.config/gh-dash/config.yml"
+
+    # herdr keeps live sockets, logs and its own plugin checkouts in
+    # ~/.config/herdr, so the directory itself must stay real — link only the
+    # pieces this repo owns.
+    as_user mkdir -p "$HOME/.config/herdr"
+    link_config herdr/config.toml "$HOME/.config/herdr/config.toml"
+    link_config herdr/scripts "$HOME/.config/herdr/scripts"
+
+    # tmux.conf references this by name, so it has to resolve on PATH.
+    link_config scripts/tmux-background-install-indicator.sh \
+        "$HOME/.local/bin/tmux-background-install-indicator.sh"
+}
+
+# --------------------------------------------------------------- plugins -----
+
+install_tmux_plugins() {
+    $DO_TMUX || { skip "Skipping tmux plugins (--skip-tmux)"; return; }
+    step "Setting up tmux plugins"
+
+    local tpm="$HOME/.config/tmux/plugins/tpm"
+    if [ -d "$tpm/.git" ]; then
+        skip "tpm already cloned"
+    else
+        as_user mkdir -p "$HOME/.config/tmux/plugins"
+        as_user git clone --depth 1 https://github.com/tmux-plugins/tpm "$tpm"
+        ok "Cloned tpm"
+    fi
+
+    # Some plugins still look in the legacy ~/.tmux location.
+    as_user mkdir -p "$HOME/.tmux/plugins"
+    if [ ! -e "$HOME/.tmux/plugins/tpm" ]; then
+        as_user ln -sfn "$tpm" "$HOME/.tmux/plugins/tpm"
+    fi
+
+    if ! have tmux && ! $DRY_RUN; then
+        warn "tmux not on PATH; skipping plugin install (re-run after opening a new shell)"
+        return
+    fi
+
+    # tmux-thumbs and tmux-floax build with cargo, so this needs the mise rust.
+    log "Installing tmux plugins (a couple of these build from source)"
+    as_user "$tpm/bin/install_plugins" >>"$LOG_FILE" 2>&1 ||
+        warn "Some tmux plugins failed to install — see $LOG_FILE"
+    ok "tmux plugins installed"
+}
+
+sync_neovim() {
+    $DO_NVIM || { skip "Skipping neovim sync (--skip-nvim)"; return; }
+    step "Syncing neovim plugins"
+
+    if ! have nvim && ! $DRY_RUN; then
+        warn "nvim not on PATH; skipping (run 'nvim' once to let lazy.nvim bootstrap)"
+        return
+    fi
+
+    log "Running lazy.nvim sync headless (a few minutes on a first run)"
+    as_user nvim --headless "+Lazy! sync" +qa >>"$LOG_FILE" 2>&1 ||
+        warn "Neovim plugin sync reported errors — see $LOG_FILE"
+    ok "Neovim plugins synced"
+}
+
+install_herdr_plugins() {
+    $DO_HERDR || { skip "Skipping herdr plugins (--skip-herdr)"; return; }
+    step "Installing herdr plugins"
+
+    if ! have herdr && ! $DRY_RUN; then
+        warn "herdr not on PATH; skipping plugin install"
+        return
+    fi
+
+    local plugin
+    for plugin in \
+        paulbkim-dev/vim-herdr-navigation \
+        JanTvrdik/herdr-command-palette \
+        rmarganti/herdr-pluck \
+        Tyru5/herdr-floax \
+        thanhdat77/herdr-navigator \
+        iurysza/termscope; do
+        as_user herdr plugin install "$plugin" --yes >>"$LOG_FILE" 2>&1 ||
+            warn "Failed to install herdr plugin $plugin — see $LOG_FILE"
+    done
+    ok "herdr plugins installed"
+}
+
+# ------------------------------------------------------------ login shell ----
+
+set_login_shell() {
+    $SET_FISH_SHELL || return 0
+    step "Making fish the login shell"
+
+    local fish_path
+    if $DRY_RUN; then
+        fish_path="$HOME/.local/share/mise/installs/fish/latest/bin/fish"
+    else
+        fish_path="$(mise which fish 2>/dev/null || command -v fish || true)"
+        if [ -z "$fish_path" ]; then
+            warn "fish not found; not changing the login shell"
+            return 0
+        fi
+    fi
+
+    if [ "${SHELL:-}" = "$fish_path" ]; then
+        skip "fish is already the login shell"
+        return
+    fi
+
+    if ! grep -qxF "$fish_path" /etc/shells 2>/dev/null; then
+        printf '%s\n' "$fish_path" | as_root tee -a /etc/shells >/dev/null
+    fi
+    as_user chsh -s "$fish_path" ||
+        warn "chsh failed; run: chsh -s $fish_path"
+
+    warn "Your login shell now depends on mise. Open a second SSH session and confirm it works before closing this one."
+    ok "Login shell set to $fish_path"
+}
+
+# ----------------------------------------------------------------- main ------
+
+main() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --skip-apt)    DO_APT=false ;;
+            --skip-mise)   DO_MISE=false ;;
+            --skip-links)  DO_LINKS=false ;;
+            --skip-tmux)   DO_TMUX=false ;;
+            --skip-nvim)   DO_NVIM=false ;;
+            --skip-herdr)  DO_HERDR=false ;;
+            --fish-shell)  SET_FISH_SHELL=true ;;
+            --force)       FORCE=true ;;
+            --dry-run)     DRY_RUN=true ;;
+            --yes|-y)      ASSUME_YES=true ;;
+            --help|-h)     show_help; exit 0 ;;
+            *) printf 'Unknown option: %s\nUse --help for usage.\n' "$1" >&2; exit 1 ;;
+        esac
+        shift
+    done
+
+    : >"$LOG_FILE"
+    local start_time
+    start_time=$(date +%s)
+
+    printf '%s🍓 install-pi — Raspberry Pi dotfiles setup%s\n' "$C_BOLD" "$C_RESET"
+    if $DRY_RUN; then
+        log "${C_YELLOW}Dry run: nothing will be changed${C_RESET}"
+    fi
+
+    preflight
+    # Both apt and /etc/shells need root; everything else runs as you.
+    if $DO_APT || $SET_FISH_SHELL; then
+        setup_sudo
+    fi
+    install_apt_packages
+    install_mise
+    link_configs
+    install_mise_tools
+    install_tmux_plugins
+    sync_neovim
+    install_herdr_plugins
+    set_login_shell
+
+    local elapsed=$(( $(date +%s) - start_time ))
+    step "Done in $((elapsed / 60))m $((elapsed % 60))s"
+    log "Log: $LOG_FILE"
+    if [ -d "$BACKUP_DIR" ]; then
+        log "Replaced configs were backed up to $BACKUP_DIR"
+    fi
+    printf '\nNext:\n'
+    printf '  • Open a new shell so mise shims are on PATH.\n'
+    if $SET_FISH_SHELL; then
+        printf '  • Verify fish works in a second SSH session before closing this one.\n'
+    else
+        printf '  • Run ./install-pi --fish-shell to make fish your login shell.\n'
+    fi
+    printf "  • Sync shell history: atuin login -u <user>\n"
+}
+
+main "$@"

--- a/pi/install.sh
+++ b/pi/install.sh
@@ -75,10 +75,12 @@ die()  { log "${C_RED}✗${C_RESET} $*"; exit 1; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # A dry run must leave the disk untouched, including whatever INSTALL_PI_LOG
-# points at, which a real run truncates. So it logs to a throwaway file.
+# points at, which a real run truncates. It has nothing worth keeping either —
+# every line also goes to the terminal — so it logs to /dev/null rather than a
+# temporary file it would have to clean up.
 init_logging() {
     if $DRY_RUN; then
-        LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/install-pi-dry-run.XXXXXX")"
+        LOG_FILE=/dev/null
         return 0
     fi
     LOG_FILE="${INSTALL_PI_LOG:-$HOME/install-pi.log}"
@@ -258,7 +260,11 @@ preflight() {
         die "$DOTFILES_DIR does not look like the dotfiles repo (no fish/ directory)."
     ok "Dotfiles: $DOTFILES_DIR"
     ok "Provisioning: $TARGET_USER (home: $HOME)"
-    ok "Log: $LOG_FILE"
+    if $DRY_RUN; then
+        ok "Log: not written (dry run)"
+    else
+        ok "Log: $LOG_FILE"
+    fi
 
     if ! $ASSUME_YES && ! $DRY_RUN && [ -t 0 ]; then
         printf '\nProceed? [Y/n] '
@@ -301,9 +307,13 @@ install_apt_packages() {
 
 ensure_locale() {
     # fish, neovim and the Catppuccin/nerd-font glyphs all assume a UTF-8
-    # locale; Raspberry Pi OS Lite ships without one generated.
-    if locale -a 2>/dev/null | grep -qiE '^(en_US\.utf-?8|C\.utf-?8)$'; then
-        skip "UTF-8 locale already available"
+    # locale; Raspberry Pi OS Lite ships without one generated. Any UTF-8
+    # locale will do, so a Pi already set to en_GB.UTF-8 keeps its own regional
+    # settings rather than being switched to en_US.
+    local existing
+    existing="$(locale -a 2>/dev/null | grep -iE '\.utf-?8$' | head -1)"
+    if [ -n "$existing" ]; then
+        skip "UTF-8 locale already available ($existing)"
         return
     fi
     log "Generating en_US.UTF-8 locale"
@@ -679,7 +689,7 @@ main() {
 
     local elapsed=$(( $(date +%s) - start_time ))
     step "Done in $((elapsed / 60))m $((elapsed % 60))s"
-    log "Log: $LOG_FILE"
+    $DRY_RUN || log "Log: $LOG_FILE"
     if [ -d "$BACKUP_DIR" ]; then
         log "Replaced configs were backed up to $BACKUP_DIR"
     fi

--- a/pi/install.sh
+++ b/pi/install.sh
@@ -47,6 +47,7 @@ APT_PACKAGES=(
     python3
     python3-pip
     python3-venv
+    btop
     tmuxinator
 )
 
@@ -212,6 +213,23 @@ as_user() {
     run_as_user "$@"
 }
 
+# as_user with the command's own chatter captured in the log instead of the
+# terminal. A dry run has nothing to capture and must show the planned command,
+# so it skips the redirect.
+as_user_quiet() {
+    if $DRY_RUN; then
+        as_user "$@"
+        return 0
+    fi
+    as_user "$@" >>"$LOG_FILE" 2>&1
+}
+
+# Run a command with its output on the terminal *and* in the log. pipefail
+# means the command's own exit status still wins over tee's.
+tee_log() {
+    "$@" 2>&1 | tee -a "$LOG_FILE"
+}
+
 # ---------------------------------------------------------------- checks ----
 
 preflight() {
@@ -258,12 +276,12 @@ install_apt_packages() {
     $DO_APT || { skip "Skipping apt packages (--skip-apt)"; return; }
     step "Installing apt packages"
 
-    apt_get update
+    tee_log apt_get update
 
     # One batch is much faster, but a single unavailable package (tmuxinator is
     # not in every Debian release) would abort the lot — so fall back to
     # installing individually and only warn about what is genuinely missing.
-    if apt_get install -y --no-install-recommends "${APT_PACKAGES[@]}"; then
+    if tee_log apt_get install -y --no-install-recommends "${APT_PACKAGES[@]}"; then
         ok "Installed ${#APT_PACKAGES[@]} apt packages"
     else
         warn "Batch install failed; retrying package by package"
@@ -338,8 +356,8 @@ install_mise() {
         printf '%s\n' "$line" | as_root tee /etc/apt/sources.list.d/mise.list >/dev/null
     fi
 
-    apt_get update
-    apt_get install -y mise
+    tee_log apt_get update
+    tee_log apt_get install -y mise
     ok "mise installed from its apt repository"
 }
 
@@ -352,8 +370,21 @@ install_mise_tools() {
         return 0
     fi
 
-    as_user mkdir -p "$HOME/.config/mise"
-    local mise_config="$HOME/.config/mise/config.toml"
+    local mise_dir="$HOME/.config/mise"
+    local mise_config="$mise_dir/config.toml"
+
+    # On a workstation ~/.config/mise is a symlink to this repo's mise/ (see
+    # fish/config.fish). Writing config.toml through it would rewrite the repo's
+    # own workstation manifest, so the link is replaced by a real directory.
+    if [ -L "$mise_dir" ]; then
+        if $FORCE; then
+            as_user rm -f "$mise_dir"
+        else
+            backup_path "$mise_dir"
+        fi
+    fi
+    as_user mkdir -p "$mise_dir"
+
     # A copy, not a symlink: mise treats a config resolved through a symlink
     # into the repo as non-global. That also means an existing symlink has to
     # go first, or cp would follow it and overwrite the file it points at
@@ -361,18 +392,17 @@ install_mise_tools() {
     # manifest there).
     if [ -e "$mise_config" ] || [ -L "$mise_config" ]; then
         if ! $FORCE && ! cmp -s "$PI_DIR/mise.toml" "$mise_config" 2>/dev/null; then
-            as_user mkdir -p "$BACKUP_DIR"
-            as_user cp -P "$mise_config" "$BACKUP_DIR/mise-config.toml"
-            warn "Backed up existing ~/.config/mise/config.toml to ${BACKUP_DIR/#$HOME/\~}"
+            backup_path "$mise_config"
+        else
+            as_user rm -f "$mise_config"
         fi
-        as_user rm -f "$mise_config"
     fi
     as_user cp "$PI_DIR/mise.toml" "$mise_config"
     ok "Wrote ~/.config/mise/config.toml from pi/mise.toml"
 
     as_user mise trust "$mise_config"
     log "Running mise install (downloads prebuilt binaries; a few minutes on a Pi)"
-    as_user mise install
+    tee_log as_user mise install
     ok "mise tools installed"
 
     # Later phases (tmux plugins, nvim sync, herdr) need the freshly installed
@@ -385,6 +415,18 @@ install_mise_tools() {
 }
 
 # ---------------------------------------------------------------- links ------
+
+# Move <target> into the backup tree, keeping its path relative to $HOME so
+# that two configs sharing a basename (~/.config/gh/config.yml and
+# ~/.config/gh-dash/config.yml) cannot overwrite each other's backup.
+backup_path() {
+    local target="$1" rel dest
+    rel="${target#"$HOME"/}"
+    dest="$BACKUP_DIR/$rel"
+    as_user mkdir -p "$(dirname "$dest")"
+    as_user mv "$target" "$dest"
+    warn "Backed up ${target/#$HOME/\~} to ${dest/#$HOME/\~}"
+}
 
 # link_config <repo-relative source> <absolute target>
 link_config() {
@@ -404,9 +446,7 @@ link_config() {
         if $FORCE; then
             as_user rm -rf "$target"
         else
-            as_user mkdir -p "$BACKUP_DIR"
-            as_user mv "$target" "$BACKUP_DIR/$(basename "$target")"
-            warn "Backed up existing ${target/#$HOME/\~} to ${BACKUP_DIR/#$HOME/\~}"
+            backup_path "$target"
         fi
     fi
 
@@ -488,7 +528,7 @@ install_tmux_plugins() {
 
     # tmux-thumbs and tmux-floax build with cargo, so this needs the mise rust.
     log "Installing tmux plugins (a couple of these build from source)"
-    if as_user "$tpm/bin/install_plugins" >>"$LOG_FILE" 2>&1; then
+    if as_user_quiet "$tpm/bin/install_plugins"; then
         ok "tmux plugins installed"
     else
         warn "Some tmux plugins failed to install — see $LOG_FILE"
@@ -505,7 +545,7 @@ sync_neovim() {
     fi
 
     log "Running lazy.nvim sync headless (a few minutes on a first run)"
-    if as_user nvim --headless "+Lazy! sync" +qa >>"$LOG_FILE" 2>&1; then
+    if as_user_quiet nvim --headless "+Lazy! sync" +qa; then
         ok "Neovim plugins synced"
     else
         warn "Neovim plugin sync reported errors — see $LOG_FILE"
@@ -521,6 +561,14 @@ install_herdr_plugins() {
         return
     fi
 
+    # herdr-navigator <= v0.3.1 shipped under the plugin id `herdr-picker-plus`.
+    # The config binds `herdr-navigator.*`, so the stale id has to go or the
+    # rebuilt plugin cannot claim its actions. install.sh does the same.
+    if ! $DRY_RUN && run_as_user herdr plugin list 2>/dev/null | grep -q '^- herdr-picker-plus '; then
+        as_user_quiet herdr plugin uninstall herdr-picker-plus ||
+            warn "Failed to remove the legacy herdr plugin herdr-picker-plus"
+    fi
+
     local plugin failed=()
     for plugin in \
         paulbkim-dev/vim-herdr-navigation \
@@ -529,7 +577,7 @@ install_herdr_plugins() {
         Tyru5/herdr-floax \
         thanhdat77/herdr-navigator \
         iurysza/termscope; do
-        as_user herdr plugin install "$plugin" --yes >>"$LOG_FILE" 2>&1 ||
+        as_user_quiet herdr plugin install "$plugin" --yes ||
             failed+=("$plugin")
     done
     if [ ${#failed[@]} -gt 0 ]; then

--- a/pi/install.sh
+++ b/pi/install.sh
@@ -123,8 +123,8 @@ Options:
   --help, -h        Show this help
 
 Environment:
-  INSTALL_PI_LOG    Log file path (default: ~/install-pi.log). --dry-run logs
-                    to a temporary file and leaves this one alone.
+  INSTALL_PI_LOG    Log file path (default: ~/install-pi.log). --dry-run does
+                    not write a log, and leaves this file alone.
 
 Everything is idempotent — re-run it after `git pull` to pick up changes.
 EOF
@@ -311,7 +311,10 @@ ensure_locale() {
     # locale will do, so a Pi already set to en_GB.UTF-8 keeps its own regional
     # settings rather than being switched to en_US.
     local existing
-    existing="$(locale -a 2>/dev/null | grep -iE '\.utf-?8$' | head -1)"
+    # grep exits 1 when a fresh Raspberry Pi OS Lite image has no UTF-8 locale
+    # at all, which is precisely the case this function exists to handle, so
+    # the no-match status must not trip `set -e`.
+    existing="$(locale -a 2>/dev/null | grep -iE '\.utf-?8$' | head -1 || true)"
     if [ -n "$existing" ]; then
         skip "UTF-8 locale already available ($existing)"
         return
@@ -604,15 +607,17 @@ set_login_shell() {
     step "Making fish the login shell"
 
     local fish_path
-    if $DRY_RUN; then
-        fish_path="$HOME/.local/share/mise/installs/fish/latest/bin/fish"
-    else
-        fish_path="$(run_as_user mise which fish 2>/dev/null || true)"
-        [ -n "$fish_path" ] || fish_path="$(command -v fish || true)"
-        if [ -z "$fish_path" ]; then
+    # mise which / command -v are read-only, so a dry run resolves the real
+    # path rather than guessing at mise's backend-specific install layout.
+    fish_path="$(run_as_user mise which fish 2>/dev/null || true)"
+    [ -n "$fish_path" ] || fish_path="$(command -v fish || true)"
+    if [ -z "$fish_path" ]; then
+        if $DRY_RUN; then
+            log "${C_DIM}[dry-run] fish is not installed yet; its path would come from 'mise which fish' after step 4${C_RESET}"
+        else
             warn "fish not found; not changing the login shell"
-            return 0
         fi
+        return 0
     fi
 
     local current_shell

--- a/pi/mise.toml
+++ b/pi/mise.toml
@@ -1,0 +1,56 @@
+# Raspberry Pi tool manifest — installed to ~/.config/mise/config.toml by
+# ./install-pi.
+#
+# Targets 64-bit Raspberry Pi OS (arm64). Several of these publish aarch64
+# Linux binaries only, so this manifest does not work on 32-bit armhf.
+#
+# Everything here downloads a prebuilt binary — nothing compiles — so a full
+# `mise install` on a Pi 4/5 is minutes, not hours.
+#
+# Derived from Telephone-Booth's packaging/raspberry-pi/mise.toml, with the
+# extra tools these dotfiles assume (fish's config.fish sources zoxide and
+# fzf, tmux-thumbs builds with cargo, nvim's LSPs need node).
+
+[tools]
+tmux = "latest"
+bat = "latest"
+eza = "latest"
+neovim = "latest"
+starship = "latest"
+atuin = "latest"
+zellij = "latest"
+bottom = "latest"   # provides the `btm` binary
+delta = "latest"    # git-delta
+herdr = "latest"    # agent multiplexer for the terminal
+
+# Sourced unconditionally by fish/config.fish, so fish errors on every prompt
+# without them.
+zoxide = "latest"
+fzf = "latest"
+
+# Used by nvim (telescope, grep pickers) and the tmux fzf plugins.
+ripgrep = "latest"
+fd = "latest"
+
+jq = "latest"
+gh = "latest"
+yazi = "latest"
+lazygit = "latest"
+
+# node backs the nvim language servers and copilot; rust gives cargo, which
+# tmux-thumbs and tmux-floax need at plugin-install time.
+node = "latest"
+rust = "latest"
+
+# fish has no short registry name in mise, so name the aqua backend directly.
+# Upstream ships a self-contained static aarch64 binary from 4.0 onward, which
+# is far newer than Debian's package. `install-pi --fish-shell` makes it the
+# login shell.
+"aqua:fish-shell/fish-shell" = "latest"
+
+[settings]
+experimental = true
+jobs = 4
+not_found_auto_install = true
+idiomatic_version_file_enable_tools = ['node', 'rust']
+status = { missing_tools = "if_other_versions_installed", show_env = false, show_tools = false }

--- a/pi/mise.toml
+++ b/pi/mise.toml
@@ -32,6 +32,11 @@ fzf = "latest"
 ripgrep = "latest"
 fd = "latest"
 
+# termscope's own build step installs Television through Homebrew, which a Pi
+# does not have, so provide `tv` up front. README.md's plugin prerequisites
+# table requires 0.15+.
+television = "latest"
+
 jq = "latest"
 gh = "latest"
 yazi = "latest"


### PR DESCRIPTION
Provisioning a Pi meant hand-walking Telephone-Booth's `docs/raspberry-pi-tools.md` (mise apt repo, tool manifest, fish as login shell) and then separately reproducing the symlinks `install.sh` makes for Codespaces. `./install-pi` does the whole thing in one pass:

```bash
git clone https://github.com/djensenius/dotfiles.git ~/.dotfiles && cd ~/.dotfiles && ./install-pi
```

## What's here

- `install-pi` — entry point at the repo root.
- `pi/install.sh` — seven idempotent phases: apt packages, mise from its own apt repository, `~/.config` symlinks, `mise install` against the Pi manifest, tmux plugins, headless lazy.nvim sync, herdr plugins. Each is skippable; `--dry-run` prints every action without taking it.
- `pi/mise.toml` — the Pi tool manifest.
- `pi/README.md` — full step list, options, and the login-shell caveat.

## Details worth noting

- **Privileges are explicit.** The account being provisioned is resolved up front — `$SUDO_USER` under `sudo`, otherwise the current user — and `HOME` is repointed at it. `as_root` escalates only for apt, `/etc/shells` and `chsh`; everything else goes through `as_user`, which demotes back to that account with `sudo -u`, so `sudo ./install-pi` configures your account rather than root's and leaves nothing under `~` root-owned. The sudo credential cache is primed so the run doesn't block on a password prompt halfway through.
- **Backups, not deletions.** Existing configs move to `~/.dotfiles-backup/<timestamp>/`. (`install.sh`'s `rm -rf ~/.config/fish` is fine for a throwaway Codespace, less so for a machine you live on.) `--force` restores the destructive behaviour.
- **`--dry-run` really is read-only**, down to the log: it writes to a throwaway file under `TMPDIR` rather than truncating `INSTALL_PI_LOG`.
- **`~/.config/mise/config.toml` is a copy, not a symlink** — mise treats a config reached through a symlink into the repo as non-global. The existing entry is unlinked before the copy, because `cp` would otherwise follow a symlink and overwrite `mise/config.toml` *inside this repo* for anyone who linked the workstation manifest there.
- **apt installs in one batch**, falling back to package-by-package on failure, so one package missing from a release (tmuxinator isn't in every one) doesn't abort the rest.
- **`--fish-shell` is opt-in.** A mise-managed fish lives under `~`, so making it the login shell couples logins — and `ssh host <command>` — to mise.

`pi/mise.toml` starts from Telephone-Booth's `packaging/raspberry-pi/mise.toml` and adds what these dotfiles assume: zoxide and fzf (sourced unconditionally by `fish/config.fish`, so fish errors on every prompt without them), ripgrep and fd for the nvim/tmux pickers, node for the language servers, and rust because tmux-thumbs and tmux-floax build with cargo at plugin-install time. Every manifest entry resolves to a prebuilt aarch64 binary, so the only compilation in a full run is those two tmux plugins.

## Testing

shellcheck and tomllint clean. Exercised end to end under a stubbed Linux environment: the dry run (confirming an existing `INSTALL_PI_LOG` survives untouched), the real link phase (backup and already-linked paths), re-run idempotency, the `sudo` path (every non-privileged command demoted to `$SUDO_USER`, nothing written to root's home, `chsh` naming the right account), the failure branches for the tmux/nvim/herdr/chsh phases, and confirmation that a `~/.config/mise/config.toml` symlinked at the repo leaves the repo file untouched. Every tool name was verified to resolve via `mise registry` / `mise ls --current`.
