### PR TITLE
Fix deprecated mise task output setting

### DIFF
--- a/mise/config-test.toml
+++ b/mise/config-test.toml
@@ -64,7 +64,7 @@ raw = false           # set to true to directly pipe plugins to stdin/stdout/std
 yes = false           # set to true to automatically answer yes to all prompts
 
 not_found_auto_install = true # see MISE_NOT_FOUND_AUTO_INSTALL
-task_output = "prefix" # see Tasks Runner for more information
+task.output = "prefix" # see Tasks Runner for more information
 paranoid = false       # see MISE_PARANOID
 
 disable_default_shorthands = false # disable the default shorthands, see `MISE_DISABLE_DEFAULT_SHORTHANDS`

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -64,7 +64,7 @@ jobs = 4              # number of plugins or runtimes to install in parallel. Th
 raw = false           # set to true to directly pipe plugins to stdin/stdout/stderr
 
 not_found_auto_install = true # see MISE_NOT_FOUND_AUTO_INSTALL
-task_output = "prefix" # see Tasks Runner for more information
+task.output = "prefix" # see Tasks Runner for more information
 
 disable_default_registry = false # disable the default shorthands, see `MISE_DISABLE_DEFAULT_SHORTHANDS`
 # disable_tools = ['node']           # disable specific tools, generally used to turn off core tools


### PR DESCRIPTION
## Summary
- replace deprecated `task_output` with `task.output`
- update both primary and test mise configurations

## Validation
- `tomllint`
- `actionlint`
- `mise settings`
- `git diff --check`

Repository-wide `yamllint .` remains blocked by pre-existing violations in vendored `tmux/plugins` files.